### PR TITLE
Use unchecked indexing for faster "forfft/revfft" execution

### DIFF
--- a/shallow_water/src/stafft/forward.rs
+++ b/shallow_water/src/stafft/forward.rs
@@ -75,156 +75,168 @@ pub fn forrdx6(
 
     let mut kc: usize;
 
-    // Do k=0 first:
-    for i in 0..nv {
-        t1r = a[[i, 2, 0]] + a[[i, 4, 0]];
-        t2r = a[[i, 0, 0]] - 0.5 * t1r;
-        t3r = SINFPI3 * (a[[i, 4, 0]] - a[[i, 2, 0]]);
-        u0r = a[[i, 0, 0]] + t1r;
-        t1i = a[[i, 5, 0]] + a[[i, 1, 0]];
-        t2i = a[[i, 3, 0]] - 0.5 * t1i;
-        t3i = SINFPI3 * (a[[i, 5, 0]] - a[[i, 1, 0]]);
-        v0r = a[[i, 3, 0]] + t1i;
-        b[[i, 0, 0]] = u0r + v0r;
-        b[[i, 0, 1]] = t2r - t2i;
-        b[[i, 0, 2]] = t2r + t2i;
-        b[[i, 0, 3]] = u0r - v0r;
-        b[[i, 0, 4]] = t3i - t3r;
-        b[[i, 0, 5]] = t3r + t3i;
-    }
-    // Next do remaining k:
-    if nv <= (lv - 1) / 2 {
+    unsafe {
+        // Do k=0 first:
         for i in 0..nv {
+            t1r = a.uget((i, 2, 0)) + a.uget((i, 4, 0));
+            t2r = a.uget((i, 0, 0)) - 0.5 * t1r;
+            t3r = SINFPI3 * (a.uget((i, 4, 0)) - a.uget((i, 2, 0)));
+            u0r = a.uget((i, 0, 0)) + t1r;
+            t1i = a.uget((i, 5, 0)) + a.uget((i, 1, 0));
+            t2i = a.uget((i, 3, 0)) - 0.5 * t1i;
+            t3i = SINFPI3 * (a.uget((i, 5, 0)) - a.uget((i, 1, 0)));
+            v0r = a.uget((i, 3, 0)) + t1i;
+            *b.uget_mut((i, 0, 0)) = u0r + v0r;
+            *b.uget_mut((i, 0, 1)) = t2r - t2i;
+            *b.uget_mut((i, 0, 2)) = t2r + t2i;
+            *b.uget_mut((i, 0, 3)) = u0r - v0r;
+            *b.uget_mut((i, 0, 4)) = t3i - t3r;
+            *b.uget_mut((i, 0, 5)) = t3r + t3i;
+        }
+        // Next do remaining k:
+        if nv <= (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+                    x1p = cosine.uget((k, 0)) * a.uget((i, 1, k))
+                        - sine.uget((k, 0)) * a.uget((i, 1, kc));
+                    y1p = cosine.uget((k, 0)) * a.uget((i, 1, kc))
+                        + sine.uget((k, 0)) * a.uget((i, 1, k));
+                    x2p = cosine.uget((k, 1)) * a.uget((i, 2, k))
+                        - sine.uget((k, 1)) * a.uget((i, 2, kc));
+                    y2p = cosine.uget((k, 1)) * a.uget((i, 2, kc))
+                        + sine.uget((k, 1)) * a.uget((i, 2, k));
+                    x3p = cosine.uget((k, 2)) * a.uget((i, 3, k))
+                        - sine.uget((k, 2)) * a.uget((i, 3, kc));
+                    y3p = cosine.uget((k, 2)) * a.uget((i, 3, kc))
+                        + sine.uget((k, 2)) * a.uget((i, 3, k));
+                    x4p = cosine.uget((k, 3)) * a.uget((i, 4, k))
+                        - sine.uget((k, 3)) * a.uget((i, 4, kc));
+                    y4p = cosine.uget((k, 3)) * a.uget((i, 4, kc))
+                        + sine.uget((k, 3)) * a.uget((i, 4, k));
+                    x5p = cosine.uget((k, 3)) * a.uget((i, 5, k))
+                        - sine.uget((k, 4)) * a.uget((i, 5, kc));
+                    y5p = cosine.uget((k, 3)) * a.uget((i, 5, kc))
+                        + sine.uget((k, 4)) * a.uget((i, 5, k));
+                    t1r = x2p + x4p;
+                    t1i = y2p + y4p;
+                    t2r = a.uget((i, 0, k)) - 0.5 * t1r;
+                    t2i = a.uget((i, 0, kc)) - 0.5 * t1i;
+                    t3r = SINFPI3 * (x2p - x4p);
+                    t3i = SINFPI3 * (y2p - y4p);
+                    u0r = a.uget((i, 0, k)) + t1r;
+                    u0i = a.uget((i, 0, kc)) + t1i;
+                    u1r = t2r + t3i;
+                    u1i = t2i - t3r;
+                    u2r = t2r - t3i;
+                    u2i = t2i + t3r;
+                    t1r = x5p + x1p;
+                    t1i = y5p + y1p;
+                    t2r = x3p - 0.5 * t1r;
+                    t2i = y3p - 0.5 * t1i;
+                    t3r = SINFPI3 * (x5p - x1p);
+                    t3i = SINFPI3 * (y5p - y1p);
+                    v0r = x3p + t1r;
+                    v0i = y3p + t1i;
+                    v1r = t2r + t3i;
+                    v1i = t3r - t2i;
+                    v2r = t2r - t3i;
+                    v2i = t2i + t3r;
+                    *b.uget_mut((i, k, 0)) = u0r + v0r;
+                    *b.uget_mut((i, kc, 0)) = u2r - v2r;
+                    *b.uget_mut((i, k, 1)) = u1r - v1r;
+                    *b.uget_mut((i, kc, 1)) = u1r + v1r;
+                    *b.uget_mut((i, k, 2)) = u2r + v2r;
+                    *b.uget_mut((i, kc, 2)) = u0r - v0r;
+                    *b.uget_mut((i, k, 3)) = v0i - u0i;
+                    *b.uget_mut((i, kc, 3)) = u2i + v2i;
+                    *b.uget_mut((i, k, 4)) = v1i - u1i;
+                    *b.uget_mut((i, kc, 4)) = u1i + v1i;
+                    *b.uget_mut((i, k, 5)) = v2i - u2i;
+                    *b.uget_mut((i, kc, 5)) = u0i + v0i;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
-                x1p = cosine[[k, 0]] * a[[i, 1, k]] - sine[[k, 0]] * a[[i, 1, kc]];
-                y1p = cosine[[k, 0]] * a[[i, 1, kc]] + sine[[k, 0]] * a[[i, 1, k]];
-                x2p = cosine[[k, 1]] * a[[i, 2, k]] - sine[[k, 1]] * a[[i, 2, kc]];
-                y2p = cosine[[k, 1]] * a[[i, 2, kc]] + sine[[k, 1]] * a[[i, 2, k]];
-                x3p = cosine[[k, 2]] * a[[i, 3, k]] - sine[[k, 2]] * a[[i, 3, kc]];
-                y3p = cosine[[k, 2]] * a[[i, 3, kc]] + sine[[k, 2]] * a[[i, 3, k]];
-                x4p = cosine[[k, 3]] * a[[i, 4, k]] - sine[[k, 3]] * a[[i, 4, kc]];
-                y4p = cosine[[k, 3]] * a[[i, 4, kc]] + sine[[k, 3]] * a[[i, 4, k]];
-                x5p = cosine[[k, 3]] * a[[i, 5, k]] - sine[[k, 4]] * a[[i, 5, kc]];
-                y5p = cosine[[k, 3]] * a[[i, 5, kc]] + sine[[k, 4]] * a[[i, 5, k]];
-                t1r = x2p + x4p;
-                t1i = y2p + y4p;
-                t2r = a[[i, 0, k]] - 0.5 * t1r;
-                t2i = a[[i, 0, kc]] - 0.5 * t1i;
-                t3r = SINFPI3 * (x2p - x4p);
-                t3i = SINFPI3 * (y2p - y4p);
-                u0r = a[[i, 0, k]] + t1r;
-                u0i = a[[i, 0, kc]] + t1i;
-                u1r = t2r + t3i;
-                u1i = t2i - t3r;
-                u2r = t2r - t3i;
-                u2i = t2i + t3r;
-                t1r = x5p + x1p;
-                t1i = y5p + y1p;
-                t2r = x3p - 0.5 * t1r;
-                t2i = y3p - 0.5 * t1i;
-                t3r = SINFPI3 * (x5p - x1p);
-                t3i = SINFPI3 * (y5p - y1p);
-                v0r = x3p + t1r;
-                v0i = y3p + t1i;
-                v1r = t2r + t3i;
-                v1i = t3r - t2i;
-                v2r = t2r - t3i;
-                v2i = t2i + t3r;
-                b[[i, k, 0]] = u0r + v0r;
-                b[[i, kc, 0]] = u2r - v2r;
-                b[[i, k, 1]] = u1r - v1r;
-                b[[i, kc, 1]] = u1r + v1r;
-                b[[i, k, 2]] = u2r + v2r;
-                b[[i, kc, 2]] = u0r - v0r;
-                b[[i, k, 3]] = v0i - u0i;
-                b[[i, kc, 3]] = u2i + v2i;
-                b[[i, k, 4]] = v1i - u1i;
-                b[[i, kc, 4]] = u1i + v1i;
-                b[[i, k, 5]] = v2i - u2i;
-                b[[i, kc, 5]] = u0i + v0i;
+                c1k = *cosine.uget((k, 0));
+                s1k = *sine.uget((k, 0));
+                c2k = *cosine.uget((k, 1));
+                s2k = *sine.uget((k, 1));
+                c3k = *cosine.uget((k, 2));
+                s3k = *sine.uget((k, 2));
+                c4k = *cosine.uget((k, 3));
+                s4k = *sine.uget((k, 3));
+                c5k = *cosine.uget((k, 4));
+                s5k = *sine.uget((k, 4));
+                for i in 0..nv {
+                    x1p = c1k * a.uget((i, 1, k)) - s1k * a.uget((i, 1, kc));
+                    y1p = c1k * a.uget((i, 1, kc)) + s1k * a.uget((i, 1, k));
+                    x2p = c2k * a.uget((i, 2, k)) - s2k * a.uget((i, 2, kc));
+                    y2p = c2k * a.uget((i, 2, kc)) + s2k * a.uget((i, 2, k));
+                    x3p = c3k * a.uget((i, 3, k)) - s3k * a.uget((i, 3, kc));
+                    y3p = c3k * a.uget((i, 3, kc)) + s3k * a.uget((i, 3, k));
+                    x4p = c4k * a.uget((i, 4, k)) - s4k * a.uget((i, 4, kc));
+                    y4p = c4k * a.uget((i, 4, kc)) + s4k * a.uget((i, 4, k));
+                    x5p = c5k * a.uget((i, 5, k)) - s5k * a.uget((i, 5, kc));
+                    y5p = c5k * a.uget((i, 5, kc)) + s5k * a.uget((i, 5, k));
+                    t1r = x2p + x4p;
+                    t1i = y2p + y4p;
+                    t2r = a.uget((i, 0, k)) - 0.5 * t1r;
+                    t2i = a.uget((i, 0, kc)) - 0.5 * t1i;
+                    t3r = SINFPI3 * (x2p - x4p);
+                    t3i = SINFPI3 * (y2p - y4p);
+                    u0r = a.uget((i, 0, k)) + t1r;
+                    u0i = a.uget((i, 0, kc)) + t1i;
+                    u1r = t2r + t3i;
+                    u1i = t2i - t3r;
+                    u2r = t2r - t3i;
+                    u2i = t2i + t3r;
+                    t1r = x5p + x1p;
+                    t1i = y5p + y1p;
+                    t2r = x3p - 0.5 * t1r;
+                    t2i = y3p - 0.5 * t1i;
+                    t3r = SINFPI3 * (x5p - x1p);
+                    t3i = SINFPI3 * (y5p - y1p);
+                    v0r = x3p + t1r;
+                    v0i = y3p + t1i;
+                    v1r = t2r + t3i;
+                    v1i = t3r - t2i;
+                    v2r = t2r - t3i;
+                    v2i = t2i + t3r;
+                    *b.uget_mut((i, k, 0)) = u0r + v0r;
+                    *b.uget_mut((i, kc, 0)) = u2r - v2r;
+                    *b.uget_mut((i, k, 1)) = u1r - v1r;
+                    *b.uget_mut((i, kc, 1)) = u1r + v1r;
+                    *b.uget_mut((i, k, 2)) = u2r + v2r;
+                    *b.uget_mut((i, kc, 2)) = u0r - v0r;
+                    *b.uget_mut((i, k, 3)) = v0i - u0i;
+                    *b.uget_mut((i, kc, 3)) = u2i + v2i;
+                    *b.uget_mut((i, k, 4)) = v1i - u1i;
+                    *b.uget_mut((i, kc, 4)) = u1i + v1i;
+                    *b.uget_mut((i, k, 5)) = v2i - u2i;
+                    *b.uget_mut((i, kc, 5)) = u0i + v0i;
+                }
             }
         }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[k, 0]];
-            s1k = sine[[k, 0]];
-            c2k = cosine[[k, 1]];
-            s2k = sine[[k, 1]];
-            c3k = cosine[[k, 2]];
-            s3k = sine[[k, 2]];
-            c4k = cosine[[k, 3]];
-            s4k = sine[[k, 3]];
-            c5k = cosine[[k, 4]];
-            s5k = sine[[k, 4]];
-            for i in 0..nv {
-                x1p = c1k * a[[i, 1, k]] - s1k * a[[i, 1, kc]];
-                y1p = c1k * a[[i, 1, kc]] + s1k * a[[i, 1, k]];
-                x2p = c2k * a[[i, 2, k]] - s2k * a[[i, 2, kc]];
-                y2p = c2k * a[[i, 2, kc]] + s2k * a[[i, 2, k]];
-                x3p = c3k * a[[i, 3, k]] - s3k * a[[i, 3, kc]];
-                y3p = c3k * a[[i, 3, kc]] + s3k * a[[i, 3, k]];
-                x4p = c4k * a[[i, 4, k]] - s4k * a[[i, 4, kc]];
-                y4p = c4k * a[[i, 4, kc]] + s4k * a[[i, 4, k]];
-                x5p = c5k * a[[i, 5, k]] - s5k * a[[i, 5, kc]];
-                y5p = c5k * a[[i, 5, kc]] + s5k * a[[i, 5, k]];
-                t1r = x2p + x4p;
-                t1i = y2p + y4p;
-                t2r = a[[i, 0, k]] - 0.5 * t1r;
-                t2i = a[[i, 0, kc]] - 0.5 * t1i;
-                t3r = SINFPI3 * (x2p - x4p);
-                t3i = SINFPI3 * (y2p - y4p);
-                u0r = a[[i, 0, k]] + t1r;
-                u0i = a[[i, 0, kc]] + t1i;
-                u1r = t2r + t3i;
-                u1i = t2i - t3r;
-                u2r = t2r - t3i;
-                u2i = t2i + t3r;
-                t1r = x5p + x1p;
-                t1i = y5p + y1p;
-                t2r = x3p - 0.5 * t1r;
-                t2i = y3p - 0.5 * t1i;
-                t3r = SINFPI3 * (x5p - x1p);
-                t3i = SINFPI3 * (y5p - y1p);
-                v0r = x3p + t1r;
-                v0i = y3p + t1i;
-                v1r = t2r + t3i;
-                v1i = t3r - t2i;
-                v2r = t2r - t3i;
-                v2i = t2i + t3r;
-                b[[i, k, 0]] = u0r + v0r;
-                b[[i, kc, 0]] = u2r - v2r;
-                b[[i, k, 1]] = u1r - v1r;
-                b[[i, kc, 1]] = u1r + v1r;
-                b[[i, k, 2]] = u2r + v2r;
-                b[[i, kc, 2]] = u0r - v0r;
-                b[[i, k, 3]] = v0i - u0i;
-                b[[i, kc, 3]] = u2i + v2i;
-                b[[i, k, 4]] = v1i - u1i;
-                b[[i, kc, 4]] = u1i + v1i;
-                b[[i, k, 5]] = v2i - u2i;
-                b[[i, kc, 5]] = u0i + v0i;
-            }
-        }
-    }
 
-    //Catch the case k=lv/2 when lv even:
-    if lv % 2 == 0 {
-        let lvd2 = lv / 2;
-        for i in 0..nv {
-            q1 = a[[i, 2, lvd2]] - a[[i, 4, lvd2]];
-            q2 = a[[i, 0, lvd2]] + 0.5 * q1;
-            q3 = SINFPI3 * (a[[i, 2, lvd2]] + a[[i, 4, lvd2]]);
-            q4 = a[[i, 1, lvd2]] + a[[i, 5, lvd2]];
-            q5 = -a[[i, 3, lvd2]] - 0.5 * q4;
-            q6 = SINFPI3 * (a[[i, 1, lvd2]] - a[[i, 5, lvd2]]);
-            b[[i, lvd2, 0]] = q2 + q6;
-            b[[i, lvd2, 1]] = a[[i, 0, lvd2]] - q1;
-            b[[i, lvd2, 2]] = q2 - q6;
-            b[[i, lvd2, 3]] = q5 + q3;
-            b[[i, lvd2, 4]] = a[[i, 3, lvd2]] - q4;
-            b[[i, lvd2, 5]] = q5 - q3;
+        //Catch the case k=lv/2 when lv even:
+        if lv % 2 == 0 {
+            let lvd2 = lv / 2;
+            for i in 0..nv {
+                q1 = a.uget((i, 2, lvd2)) - a.uget((i, 4, lvd2));
+                q2 = a.uget((i, 0, lvd2)) + 0.5 * q1;
+                q3 = SINFPI3 * (a.uget((i, 2, lvd2)) + a.uget((i, 4, lvd2)));
+                q4 = a.uget((i, 1, lvd2)) + a.uget((i, 5, lvd2));
+                q5 = -a.uget((i, 3, lvd2)) - 0.5 * q4;
+                q6 = SINFPI3 * (a.uget((i, 1, lvd2)) - a.uget((i, 5, lvd2)));
+                *b.uget_mut((i, lvd2, 0)) = q2 + q6;
+                *b.uget_mut((i, lvd2, 1)) = a.uget((i, 0, lvd2)) - q1;
+                *b.uget_mut((i, lvd2, 2)) = q2 - q6;
+                *b.uget_mut((i, lvd2, 3)) = q5 + q3;
+                *b.uget_mut((i, lvd2, 4)) = a.uget((i, 3, lvd2)) - q4;
+                *b.uget_mut((i, lvd2, 5)) = q5 - q3;
+            }
         }
     }
 }
@@ -293,120 +305,130 @@ pub fn forrdx5(
 
     let mut kc: usize;
 
-    //Do k=0 first:
-    for i in 0..nv {
-        t1r = a[[i, 1, 0]] + a[[i, 4, 0]];
-        t2r = a[[i, 2, 0]] + a[[i, 3, 0]];
-        t3r = SINF2PI5 * (a[[i, 4, 0]] - a[[i, 1, 0]]);
-        t4r = SINF2PI5 * (a[[i, 2, 0]] - a[[i, 3, 0]]);
-        t5r = t1r + t2r;
-        t6r = RTF516 * (t1r - t2r);
-        t7r = a[[i, 0, 0]] - 0.25 * t5r;
-        b[[i, 0, 0]] = a[[i, 0, 0]] + t5r;
-        b[[i, 0, 1]] = t7r + t6r;
-        b[[i, 0, 2]] = t7r - t6r;
-        b[[i, 0, 3]] = t4r + SINRAT * t3r;
-        b[[i, 0, 4]] = t3r - SINRAT * t4r;
-    }
-    //Next do remaining k:
-    if nv <= (lv - 1) / 2 {
+    unsafe {
+        //Do k=0 first:
         for i in 0..nv {
+            t1r = a.uget((i, 1, 0)) + a.uget((i, 4, 0));
+            t2r = a.uget((i, 2, 0)) + a.uget((i, 3, 0));
+            t3r = SINF2PI5 * (a.uget((i, 4, 0)) - a.uget((i, 1, 0)));
+            t4r = SINF2PI5 * (a.uget((i, 2, 0)) - a.uget((i, 3, 0)));
+            t5r = t1r + t2r;
+            t6r = RTF516 * (t1r - t2r);
+            t7r = a.uget((i, 0, 0)) - 0.25 * t5r;
+            *b.uget_mut((i, 0, 0)) = a.uget((i, 0, 0)) + t5r;
+            *b.uget_mut((i, 0, 1)) = t7r + t6r;
+            *b.uget_mut((i, 0, 2)) = t7r - t6r;
+            *b.uget_mut((i, 0, 3)) = t4r + SINRAT * t3r;
+            *b.uget_mut((i, 0, 4)) = t3r - SINRAT * t4r;
+        }
+        //Next do remaining k:
+        if nv <= (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+                    x1p = cosine.uget((k, 0)) * a.uget((i, 1, k))
+                        - sine.uget((k, 0)) * a.uget((i, 1, kc));
+                    y1p = cosine.uget((k, 0)) * a.uget((i, 1, kc))
+                        + sine.uget((k, 0)) * a.uget((i, 1, k));
+                    x2p = cosine.uget((k, 1)) * a.uget((i, 2, k))
+                        - sine.uget((k, 1)) * a.uget((i, 2, kc));
+                    y2p = cosine.uget((k, 1)) * a.uget((i, 2, kc))
+                        + sine.uget((k, 1)) * a.uget((i, 2, k));
+                    x3p = cosine.uget((k, 2)) * a.uget((i, 3, k))
+                        - sine.uget((k, 2)) * a.uget((i, 3, kc));
+                    y3p = cosine.uget((k, 2)) * a.uget((i, 3, kc))
+                        + sine.uget((k, 2)) * a.uget((i, 3, k));
+                    x4p = cosine.uget((k, 3)) * a.uget((i, 4, k))
+                        - sine.uget((k, 3)) * a.uget((i, 4, kc));
+                    y4p = cosine.uget((k, 3)) * a.uget((i, 4, kc))
+                        + sine.uget((k, 3)) * a.uget((i, 4, k));
+                    t1r = x1p + x4p;
+                    t1i = y1p + y4p;
+                    t2r = x2p + x3p;
+                    t2i = y2p + y3p;
+                    t3r = SINF2PI5 * (x1p - x4p);
+                    t3i = SINF2PI5 * (y1p - y4p);
+                    t4r = SINF2PI5 * (x2p - x3p);
+                    t4i = SINF2PI5 * (y2p - y3p);
+                    t5r = t1r + t2r;
+                    t5i = t1i + t2i;
+                    t6r = RTF516 * (t1r - t2r);
+                    t6i = RTF516 * (t1i - t2i);
+                    t7r = a.uget((i, 0, k)) - 0.25 * t5r;
+                    t7i = a.uget((i, 0, kc)) - 0.25 * t5i;
+                    t8r = t7r + t6r;
+                    t8i = t7i + t6i;
+                    t9r = t7r - t6r;
+                    t9i = t7i - t6i;
+                    t10r = t3r + SINRAT * t4r;
+                    t10i = t3i + SINRAT * t4i;
+                    t11r = t4r - SINRAT * t3r;
+                    t11i = SINRAT * t3i - t4i;
+                    *b.uget_mut((i, k, 0)) = a.uget((i, 0, k)) + t5r;
+                    *b.uget_mut((i, kc, 0)) = t8r - t10i;
+                    *b.uget_mut((i, k, 1)) = t8r + t10i;
+                    *b.uget_mut((i, kc, 1)) = t9r - t11i;
+                    *b.uget_mut((i, k, 2)) = t9r + t11i;
+                    *b.uget_mut((i, kc, 2)) = t9i + t11r;
+                    *b.uget_mut((i, k, 3)) = t11r - t9i;
+                    *b.uget_mut((i, kc, 3)) = t8i - t10r;
+                    *b.uget_mut((i, k, 4)) = -t8i - t10r;
+                    *b.uget_mut((i, kc, 4)) = a.uget((i, 0, kc)) + t5i;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
-                x1p = cosine[[k, 0]] * a[[i, 1, k]] - sine[[k, 0]] * a[[i, 1, kc]];
-                y1p = cosine[[k, 0]] * a[[i, 1, kc]] + sine[[k, 0]] * a[[i, 1, k]];
-                x2p = cosine[[k, 1]] * a[[i, 2, k]] - sine[[k, 1]] * a[[i, 2, kc]];
-                y2p = cosine[[k, 1]] * a[[i, 2, kc]] + sine[[k, 1]] * a[[i, 2, k]];
-                x3p = cosine[[k, 2]] * a[[i, 3, k]] - sine[[k, 2]] * a[[i, 3, kc]];
-                y3p = cosine[[k, 2]] * a[[i, 3, kc]] + sine[[k, 2]] * a[[i, 3, k]];
-                x4p = cosine[[k, 3]] * a[[i, 4, k]] - sine[[k, 3]] * a[[i, 4, kc]];
-                y4p = cosine[[k, 3]] * a[[i, 4, kc]] + sine[[k, 3]] * a[[i, 4, k]];
-                t1r = x1p + x4p;
-                t1i = y1p + y4p;
-                t2r = x2p + x3p;
-                t2i = y2p + y3p;
-                t3r = SINF2PI5 * (x1p - x4p);
-                t3i = SINF2PI5 * (y1p - y4p);
-                t4r = SINF2PI5 * (x2p - x3p);
-                t4i = SINF2PI5 * (y2p - y3p);
-                t5r = t1r + t2r;
-                t5i = t1i + t2i;
-                t6r = RTF516 * (t1r - t2r);
-                t6i = RTF516 * (t1i - t2i);
-                t7r = a[[i, 0, k]] - 0.25 * t5r;
-                t7i = a[[i, 0, kc]] - 0.25 * t5i;
-                t8r = t7r + t6r;
-                t8i = t7i + t6i;
-                t9r = t7r - t6r;
-                t9i = t7i - t6i;
-                t10r = t3r + SINRAT * t4r;
-                t10i = t3i + SINRAT * t4i;
-                t11r = t4r - SINRAT * t3r;
-                t11i = SINRAT * t3i - t4i;
-                b[[i, k, 0]] = a[[i, 0, k]] + t5r;
-                b[[i, kc, 0]] = t8r - t10i;
-                b[[i, k, 1]] = t8r + t10i;
-                b[[i, kc, 1]] = t9r - t11i;
-                b[[i, k, 2]] = t9r + t11i;
-                b[[i, kc, 2]] = t9i + t11r;
-                b[[i, k, 3]] = t11r - t9i;
-                b[[i, kc, 3]] = t8i - t10r;
-                b[[i, k, 4]] = -t8i - t10r;
-                b[[i, kc, 4]] = a[[i, 0, kc]] + t5i;
-            }
-        }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[k, 0]];
-            s1k = sine[[k, 0]];
-            c2k = cosine[[k, 1]];
-            s2k = sine[[k, 1]];
-            c3k = cosine[[k, 2]];
-            s3k = sine[[k, 2]];
-            c4k = cosine[[k, 3]];
-            s4k = sine[[k, 3]];
-            for i in 0..nv {
-                x1p = c1k * a[[i, 1, k]] - s1k * a[[i, 1, kc]];
-                y1p = c1k * a[[i, 1, kc]] + s1k * a[[i, 1, k]];
-                x2p = c2k * a[[i, 2, k]] - s2k * a[[i, 2, kc]];
-                y2p = c2k * a[[i, 2, kc]] + s2k * a[[i, 2, k]];
-                x3p = c3k * a[[i, 3, k]] - s3k * a[[i, 3, kc]];
-                y3p = c3k * a[[i, 3, kc]] + s3k * a[[i, 3, k]];
-                x4p = c4k * a[[i, 4, k]] - s4k * a[[i, 4, kc]];
-                y4p = c4k * a[[i, 4, kc]] + s4k * a[[i, 4, k]];
-                t1r = x1p + x4p;
-                t1i = y1p + y4p;
-                t2r = x2p + x3p;
-                t2i = y2p + y3p;
-                t3r = SINF2PI5 * (x1p - x4p);
-                t3i = SINF2PI5 * (y1p - y4p);
-                t4r = SINF2PI5 * (x2p - x3p);
-                t4i = SINF2PI5 * (y2p - y3p);
-                t5r = t1r + t2r;
-                t5i = t1i + t2i;
-                t6r = RTF516 * (t1r - t2r);
-                t6i = RTF516 * (t1i - t2i);
-                t7r = a[[i, 0, k]] - 0.25 * t5r;
-                t7i = a[[i, 0, kc]] - 0.25 * t5i;
-                t8r = t7r + t6r;
-                t8i = t7i + t6i;
-                t9r = t7r - t6r;
-                t9i = t7i - t6i;
-                t10r = t3r + SINRAT * t4r;
-                t10i = t3i + SINRAT * t4i;
-                t11r = t4r - SINRAT * t3r;
-                t11i = SINRAT * t3i - t4i;
-                b[[i, k, 0]] = a[[i, 0, k]] + t5r;
-                b[[i, kc, 0]] = t8r - t10i;
-                b[[i, k, 1]] = t8r + t10i;
-                b[[i, kc, 1]] = t9r - t11i;
-                b[[i, k, 2]] = t9r + t11i;
-                b[[i, kc, 2]] = t9i + t11r;
-                b[[i, k, 3]] = t11r - t9i;
-                b[[i, kc, 3]] = t8i - t10r;
-                b[[i, k, 4]] = -t8i - t10r;
-                b[[i, kc, 4]] = a[[i, 0, kc]] + t5i;
+                c1k = *cosine.uget((k, 0));
+                s1k = *sine.uget((k, 0));
+                c2k = *cosine.uget((k, 1));
+                s2k = *sine.uget((k, 1));
+                c3k = *cosine.uget((k, 2));
+                s3k = *sine.uget((k, 2));
+                c4k = *cosine.uget((k, 3));
+                s4k = *sine.uget((k, 3));
+                for i in 0..nv {
+                    x1p = c1k * a.uget((i, 1, k)) - s1k * a.uget((i, 1, kc));
+                    y1p = c1k * a.uget((i, 1, kc)) + s1k * a.uget((i, 1, k));
+                    x2p = c2k * a.uget((i, 2, k)) - s2k * a.uget((i, 2, kc));
+                    y2p = c2k * a.uget((i, 2, kc)) + s2k * a.uget((i, 2, k));
+                    x3p = c3k * a.uget((i, 3, k)) - s3k * a.uget((i, 3, kc));
+                    y3p = c3k * a.uget((i, 3, kc)) + s3k * a.uget((i, 3, k));
+                    x4p = c4k * a.uget((i, 4, k)) - s4k * a.uget((i, 4, kc));
+                    y4p = c4k * a.uget((i, 4, kc)) + s4k * a.uget((i, 4, k));
+                    t1r = x1p + x4p;
+                    t1i = y1p + y4p;
+                    t2r = x2p + x3p;
+                    t2i = y2p + y3p;
+                    t3r = SINF2PI5 * (x1p - x4p);
+                    t3i = SINF2PI5 * (y1p - y4p);
+                    t4r = SINF2PI5 * (x2p - x3p);
+                    t4i = SINF2PI5 * (y2p - y3p);
+                    t5r = t1r + t2r;
+                    t5i = t1i + t2i;
+                    t6r = RTF516 * (t1r - t2r);
+                    t6i = RTF516 * (t1i - t2i);
+                    t7r = a.uget((i, 0, k)) - 0.25 * t5r;
+                    t7i = a.uget((i, 0, kc)) - 0.25 * t5i;
+                    t8r = t7r + t6r;
+                    t8i = t7i + t6i;
+                    t9r = t7r - t6r;
+                    t9i = t7i - t6i;
+                    t10r = t3r + SINRAT * t4r;
+                    t10i = t3i + SINRAT * t4i;
+                    t11r = t4r - SINRAT * t3r;
+                    t11i = SINRAT * t3i - t4i;
+                    *b.uget_mut((i, k, 0)) = a.uget((i, 0, k)) + t5r;
+                    *b.uget_mut((i, kc, 0)) = t8r - t10i;
+                    *b.uget_mut((i, k, 1)) = t8r + t10i;
+                    *b.uget_mut((i, kc, 1)) = t9r - t11i;
+                    *b.uget_mut((i, k, 2)) = t9r + t11i;
+                    *b.uget_mut((i, kc, 2)) = t9i + t11r;
+                    *b.uget_mut((i, k, 3)) = t11r - t9i;
+                    *b.uget_mut((i, kc, 3)) = t8i - t10r;
+                    *b.uget_mut((i, k, 4)) = -t8i - t10r;
+                    *b.uget_mut((i, kc, 4)) = a.uget((i, 0, kc)) + t5i;
+                }
             }
         }
     }
@@ -460,90 +482,98 @@ pub fn forrdx4(
 
     let mut kc: usize;
 
-    //Do k=0 first:
-    for i in 0..nv {
-        t1r = a[[i, 0, 0]] + a[[i, 2, 0]];
-        t2r = a[[i, 1, 0]] + a[[i, 3, 0]];
-        b[[i, 0, 0]] = t1r + t2r;
-        b[[i, 0, 1]] = a[[i, 0, 0]] - a[[i, 2, 0]];
-        b[[i, 0, 2]] = t1r - t2r;
-        b[[i, 0, 3]] = a[[i, 3, 0]] - a[[i, 1, 0]];
-    }
-    //Next do remaining k:
-    if nv < (lv - 1) / 2 {
+    unsafe {
+        //Do k=0 first:
         for i in 0..nv {
+            t1r = a.uget((i, 0, 0)) + a.uget((i, 2, 0));
+            t2r = a.uget((i, 1, 0)) + a.uget((i, 3, 0));
+            *b.uget_mut((i, 0, 0)) = t1r + t2r;
+            *b.uget_mut((i, 0, 1)) = a.uget((i, 0, 0)) - a.uget((i, 2, 0));
+            *b.uget_mut((i, 0, 2)) = t1r - t2r;
+            *b.uget_mut((i, 0, 3)) = a.uget((i, 3, 0)) - a.uget((i, 1, 0));
+        }
+        //Next do remaining k:
+        if nv < (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+                    x1p = cosine.uget((k, 0)) * a.uget((i, 1, k))
+                        - sine.uget((k, 0)) * a.uget((i, 1, kc));
+                    y1p = cosine.uget((k, 0)) * a.uget((i, 1, kc))
+                        + sine.uget((k, 0)) * a.uget((i, 1, k));
+                    x2p = cosine.uget((k, 1)) * a.uget((i, 2, k))
+                        - sine.uget((k, 1)) * a.uget((i, 2, kc));
+                    y2p = cosine.uget((k, 1)) * a.uget((i, 2, kc))
+                        + sine.uget((k, 1)) * a.uget((i, 2, k));
+                    x3p = cosine.uget((k, 2)) * a.uget((i, 3, k))
+                        - sine.uget((k, 2)) * a.uget((i, 3, kc));
+                    y3p = cosine.uget((k, 2)) * a.uget((i, 3, kc))
+                        + sine.uget((k, 2)) * a.uget((i, 3, k));
+                    t1r = a.uget((i, 0, k)) + x2p;
+                    t1i = a.uget((i, 0, kc)) + y2p;
+                    t2r = x1p + x3p;
+                    t2i = y1p + y3p;
+                    t3r = a.uget((i, 0, k)) - x2p;
+                    t3i = a.uget((i, 0, kc)) - y2p;
+                    t4r = x3p - x1p;
+                    t4i = y1p - y3p;
+                    *b.uget_mut((i, k, 0)) = t1r + t2r;
+                    *b.uget_mut((i, kc, 0)) = t3r - t4i;
+                    *b.uget_mut((i, k, 1)) = t3r + t4i;
+                    *b.uget_mut((i, kc, 1)) = t1r - t2r;
+                    *b.uget_mut((i, k, 2)) = t2i - t1i;
+                    *b.uget_mut((i, kc, 2)) = t3i + t4r;
+                    *b.uget_mut((i, k, 3)) = t4r - t3i;
+                    *b.uget_mut((i, kc, 3)) = t1i + t2i;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
-                x1p = cosine[[k, 0]] * a[[i, 1, k]] - sine[[k, 0]] * a[[i, 1, kc]];
-                y1p = cosine[[k, 0]] * a[[i, 1, kc]] + sine[[k, 0]] * a[[i, 1, k]];
-                x2p = cosine[[k, 1]] * a[[i, 2, k]] - sine[[k, 1]] * a[[i, 2, kc]];
-                y2p = cosine[[k, 1]] * a[[i, 2, kc]] + sine[[k, 1]] * a[[i, 2, k]];
-                x3p = cosine[[k, 2]] * a[[i, 3, k]] - sine[[k, 2]] * a[[i, 3, kc]];
-                y3p = cosine[[k, 2]] * a[[i, 3, kc]] + sine[[k, 2]] * a[[i, 3, k]];
-                t1r = a[[i, 0, k]] + x2p;
-                t1i = a[[i, 0, kc]] + y2p;
-                t2r = x1p + x3p;
-                t2i = y1p + y3p;
-                t3r = a[[i, 0, k]] - x2p;
-                t3i = a[[i, 0, kc]] - y2p;
-                t4r = x3p - x1p;
-                t4i = y1p - y3p;
-                b[[i, k, 0]] = t1r + t2r;
-                b[[i, kc, 0]] = t3r - t4i;
-                b[[i, k, 1]] = t3r + t4i;
-                b[[i, kc, 1]] = t1r - t2r;
-                b[[i, k, 2]] = t2i - t1i;
-                b[[i, kc, 2]] = t3i + t4r;
-                b[[i, k, 3]] = t4r - t3i;
-                b[[i, kc, 3]] = t1i + t2i;
+                c1k = *cosine.uget((k, 0));
+                s1k = *sine.uget((k, 0));
+                c2k = *cosine.uget((k, 1));
+                s2k = *sine.uget((k, 1));
+                c3k = *cosine.uget((k, 2));
+                s3k = *sine.uget((k, 2));
+                for i in 0..nv {
+                    x1p = c1k * a.uget((i, 1, k)) - s1k * a.uget((i, 1, kc));
+                    y1p = c1k * a.uget((i, 1, kc)) + s1k * a.uget((i, 1, k));
+                    x2p = c2k * a.uget((i, 2, k)) - s2k * a.uget((i, 2, kc));
+                    y2p = c2k * a.uget((i, 2, kc)) + s2k * a.uget((i, 2, k));
+                    x3p = c3k * a.uget((i, 3, k)) - s3k * a.uget((i, 3, kc));
+                    y3p = c3k * a.uget((i, 3, kc)) + s3k * a.uget((i, 3, k));
+                    t1r = a.uget((i, 0, k)) + x2p;
+                    t1i = a.uget((i, 0, kc)) + y2p;
+                    t2r = x1p + x3p;
+                    t2i = y1p + y3p;
+                    t3r = a.uget((i, 0, k)) - x2p;
+                    t3i = a.uget((i, 0, kc)) - y2p;
+                    t4r = x3p - x1p;
+                    t4i = y1p - y3p;
+                    *b.uget_mut((i, k, 0)) = t1r + t2r;
+                    *b.uget_mut((i, kc, 0)) = t3r - t4i;
+                    *b.uget_mut((i, k, 1)) = t3r + t4i;
+                    *b.uget_mut((i, kc, 1)) = t1r - t2r;
+                    *b.uget_mut((i, k, 2)) = t2i - t1i;
+                    *b.uget_mut((i, kc, 2)) = t3i + t4r;
+                    *b.uget_mut((i, k, 3)) = t4r - t3i;
+                    *b.uget_mut((i, kc, 3)) = t1i + t2i;
+                }
             }
         }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[k, 0]];
-            s1k = sine[[k, 0]];
-            c2k = cosine[[k, 1]];
-            s2k = sine[[k, 1]];
-            c3k = cosine[[k, 2]];
-            s3k = sine[[k, 2]];
-            for i in 0..nv {
-                x1p = c1k * a[[i, 1, k]] - s1k * a[[i, 1, kc]];
-                y1p = c1k * a[[i, 1, kc]] + s1k * a[[i, 1, k]];
-                x2p = c2k * a[[i, 2, k]] - s2k * a[[i, 2, kc]];
-                y2p = c2k * a[[i, 2, kc]] + s2k * a[[i, 2, k]];
-                x3p = c3k * a[[i, 3, k]] - s3k * a[[i, 3, kc]];
-                y3p = c3k * a[[i, 3, kc]] + s3k * a[[i, 3, k]];
-                t1r = a[[i, 0, k]] + x2p;
-                t1i = a[[i, 0, kc]] + y2p;
-                t2r = x1p + x3p;
-                t2i = y1p + y3p;
-                t3r = a[[i, 0, k]] - x2p;
-                t3i = a[[i, 0, kc]] - y2p;
-                t4r = x3p - x1p;
-                t4i = y1p - y3p;
-                b[[i, k, 0]] = t1r + t2r;
-                b[[i, kc, 0]] = t3r - t4i;
-                b[[i, k, 1]] = t3r + t4i;
-                b[[i, kc, 1]] = t1r - t2r;
-                b[[i, k, 2]] = t2i - t1i;
-                b[[i, kc, 2]] = t3i + t4r;
-                b[[i, k, 3]] = t4r - t3i;
-                b[[i, kc, 3]] = t1i + t2i;
-            }
-        }
-    }
 
-    //Catch the case k=lv/2 when lv even:
-    if lv % 2 == 0 {
-        let lvd2 = lv / 2;
-        for i in 0..nv {
-            q1 = FRAC_1_SQRT_2 * (a[[i, 1, lvd2]] - a[[i, 3, lvd2]]);
-            q2 = FRAC_1_SQRT_2 * (a[[i, 1, lvd2]] + a[[i, 3, lvd2]]);
-            b[[i, lvd2, 0]] = a[[i, 0, lvd2]] + q1;
-            b[[i, lvd2, 1]] = a[[i, 0, lvd2]] - q1;
-            b[[i, lvd2, 2]] = a[[i, 2, lvd2]] - q2;
-            b[[i, lvd2, 3]] = -a[[i, 2, lvd2]] - q2;
+        //Catch the case k=lv/2 when lv even:
+        if lv % 2 == 0 {
+            let lvd2 = lv / 2;
+            for i in 0..nv {
+                q1 = FRAC_1_SQRT_2 * (a.uget((i, 1, lvd2)) - a.uget((i, 3, lvd2)));
+                q2 = FRAC_1_SQRT_2 * (a.uget((i, 1, lvd2)) + a.uget((i, 3, lvd2)));
+                *b.uget_mut((i, lvd2, 0)) = a.uget((i, 0, lvd2)) + q1;
+                *b.uget_mut((i, lvd2, 1)) = a.uget((i, 0, lvd2)) - q1;
+                *b.uget_mut((i, lvd2, 2)) = a.uget((i, 2, lvd2)) - q2;
+                *b.uget_mut((i, lvd2, 3)) = -a.uget((i, 2, lvd2)) - q2;
+            }
         }
     }
 }
@@ -590,60 +620,66 @@ pub fn forrdx3(
 
     let mut kc: usize;
 
-    //Do k=0 first:
-    for i in 0..nv {
-        t1r = a[[i, 1, 0]] + a[[i, 2, 0]];
-        b[[i, 0, 0]] = a[[i, 0, 0]] + t1r;
-        b[[i, 0, 1]] = a[[i, 0, 0]] - 0.5 * t1r;
-        b[[i, 0, 2]] = SINFPI3 * (a[[i, 2, 0]] - a[[i, 1, 0]]);
-    }
-    //Next do remaining k:
-    if nv <= (lv - 1) / 2 {
+    unsafe {
+        //Do k=0 first:
         for i in 0..nv {
+            t1r = a.uget((i, 1, 0)) + a.uget((i, 2, 0));
+            *b.uget_mut((i, 0, 0)) = a.uget((i, 0, 0)) + t1r;
+            *b.uget_mut((i, 0, 1)) = a.uget((i, 0, 0)) - 0.5 * t1r;
+            *b.uget_mut((i, 0, 2)) = SINFPI3 * (a.uget((i, 2, 0)) - a.uget((i, 1, 0)));
+        }
+        //Next do remaining k:
+        if nv <= (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+                    x1p = cosine.uget((k, 0)) * a.uget((i, 1, k))
+                        - sine.uget((k, 0)) * a.uget((i, 1, kc));
+                    y1p = cosine.uget((k, 0)) * a.uget((i, 1, kc))
+                        + sine.uget((k, 0)) * a.uget((i, 1, k));
+                    x2p = cosine.uget((k, 1)) * a.uget((i, 2, k))
+                        - sine.uget((k, 1)) * a.uget((i, 2, kc));
+                    y2p = cosine.uget((k, 1)) * a.uget((i, 2, kc))
+                        + sine.uget((k, 1)) * a.uget((i, 2, k));
+                    t1r = x1p + x2p;
+                    t1i = y1p + y2p;
+                    t2r = a.uget((i, 0, k)) - 0.5 * t1r;
+                    t2i = 0.5 * t1i - a.uget((i, 0, kc));
+                    t3r = SINFPI3 * (x2p - x1p);
+                    t3i = SINFPI3 * (y1p - y2p);
+                    *b.uget_mut((i, k, 0)) = a.uget((i, 0, k)) + t1r;
+                    *b.uget_mut((i, kc, 0)) = t2r - t3i;
+                    *b.uget_mut((i, k, 1)) = t2r + t3i;
+                    *b.uget_mut((i, kc, 1)) = t3r - t2i;
+                    *b.uget_mut((i, k, 2)) = t2i + t3r;
+                    *b.uget_mut((i, kc, 2)) = a.uget((i, 0, kc)) + t1i;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
-                x1p = cosine[[k, 0]] * a[[i, 1, k]] - sine[[k, 0]] * a[[i, 1, kc]];
-                y1p = cosine[[k, 0]] * a[[i, 1, kc]] + sine[[k, 0]] * a[[i, 1, k]];
-                x2p = cosine[[k, 1]] * a[[i, 2, k]] - sine[[k, 1]] * a[[i, 2, kc]];
-                y2p = cosine[[k, 1]] * a[[i, 2, kc]] + sine[[k, 1]] * a[[i, 2, k]];
-                t1r = x1p + x2p;
-                t1i = y1p + y2p;
-                t2r = a[[i, 0, k]] - 0.5 * t1r;
-                t2i = 0.5 * t1i - a[[i, 0, kc]];
-                t3r = SINFPI3 * (x2p - x1p);
-                t3i = SINFPI3 * (y1p - y2p);
-                b[[i, k, 0]] = a[[i, 0, k]] + t1r;
-                b[[i, kc, 0]] = t2r - t3i;
-                b[[i, k, 1]] = t2r + t3i;
-                b[[i, kc, 1]] = t3r - t2i;
-                b[[i, k, 2]] = t2i + t3r;
-                b[[i, kc, 2]] = a[[i, 0, kc]] + t1i;
-            }
-        }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[k, 0]];
-            s1k = sine[[k, 0]];
-            c2k = cosine[[k, 1]];
-            s2k = sine[[k, 1]];
-            for i in 0..nv {
-                x1p = c1k * a[[i, 1, k]] - s1k * a[[i, 1, kc]];
-                y1p = c1k * a[[i, 1, kc]] + s1k * a[[i, 1, k]];
-                x2p = c2k * a[[i, 2, k]] - s2k * a[[i, 2, kc]];
-                y2p = c2k * a[[i, 2, kc]] + s2k * a[[i, 2, k]];
-                t1r = x1p + x2p;
-                t1i = y1p + y2p;
-                t2r = a[[i, 0, k]] - 0.5 * t1r;
-                t2i = 0.5 * t1i - a[[i, 0, kc]];
-                t3r = SINFPI3 * (x2p - x1p);
-                t3i = SINFPI3 * (y1p - y2p);
-                b[[i, k, 0]] = a[[i, 0, k]] + t1r;
-                b[[i, kc, 0]] = t2r - t3i;
-                b[[i, k, 1]] = t2r + t3i;
-                b[[i, kc, 1]] = t3r - t2i;
-                b[[i, k, 2]] = t2i + t3r;
-                b[[i, kc, 2]] = a[[i, 0, kc]] + t1i;
+                c1k = *cosine.uget((k, 0));
+                s1k = *sine.uget((k, 0));
+                c2k = *cosine.uget((k, 1));
+                s2k = *sine.uget((k, 1));
+                for i in 0..nv {
+                    x1p = c1k * a.uget((i, 1, k)) - s1k * a.uget((i, 1, kc));
+                    y1p = c1k * a.uget((i, 1, kc)) + s1k * a.uget((i, 1, k));
+                    x2p = c2k * a.uget((i, 2, k)) - s2k * a.uget((i, 2, kc));
+                    y2p = c2k * a.uget((i, 2, kc)) + s2k * a.uget((i, 2, k));
+                    t1r = x1p + x2p;
+                    t1i = y1p + y2p;
+                    t2r = a.uget((i, 0, k)) - 0.5 * t1r;
+                    t2i = 0.5 * t1i - a.uget((i, 0, kc));
+                    t3r = SINFPI3 * (x2p - x1p);
+                    t3i = SINFPI3 * (y1p - y2p);
+                    *b.uget_mut((i, k, 0)) = a.uget((i, 0, k)) + t1r;
+                    *b.uget_mut((i, kc, 0)) = t2r - t3i;
+                    *b.uget_mut((i, k, 1)) = t2r + t3i;
+                    *b.uget_mut((i, kc, 1)) = t3r - t2i;
+                    *b.uget_mut((i, k, 2)) = t2i + t3r;
+                    *b.uget_mut((i, kc, 2)) = a.uget((i, 0, kc)) + t1i;
+                }
             }
         }
     }
@@ -679,36 +715,40 @@ pub fn forrdx2(
 
     let mut kc: usize;
 
-    //Do k=0 first:
-    for i in 0..nv {
-        b[[i, 0, 0]] = a[[i, 0, 0]] + a[[i, 1, 0]];
-        b[[i, 0, 1]] = a[[i, 0, 0]] - a[[i, 1, 0]];
-    }
-    //Next do remaining k:
-    if nv < (lv - 1) / 2 {
+    unsafe {
+        //Do k=0 first:
         for i in 0..nv {
+            *b.uget_mut([i, 0, 0]) = a.uget((i, 0, 0)) + a.uget((i, 1, 0));
+            *b.uget_mut([i, 0, 1]) = a.uget((i, 0, 0)) - a.uget((i, 1, 0));
+        }
+        //Next do remaining k:
+        if nv < (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+                    x1 = cosine[[0, k - 1]] * a.uget((i, 1, k))
+                        - sine[[0, k - 1]] * a.uget((i, 1, kc));
+                    y1 = cosine[[0, k - 1]] * a.uget((i, 1, kc))
+                        + sine[[0, k - 1]] * a.uget((i, 1, k));
+                    *b.uget_mut((i, k, 0)) = a.uget((i, 0, k)) + x1;
+                    *b.uget_mut((i, kc, 0)) = a.uget((i, 0, k)) - x1;
+                    *b.uget_mut((i, k, 1)) = y1 - a.uget((i, 0, kc));
+                    *b.uget_mut((i, kc, 1)) = a.uget((i, 0, kc)) + y1;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
-                x1 = cosine[[0, k - 1]] * a[[i, 1, k]] - sine[[0, k - 1]] * a[[i, 1, kc]];
-                y1 = cosine[[0, k - 1]] * a[[i, 1, kc]] + sine[[0, k - 1]] * a[[i, 1, k]];
-                b[[i, k, 0]] = a[[i, 0, k]] + x1;
-                b[[i, kc, 0]] = a[[i, 0, k]] - x1;
-                b[[i, k, 1]] = y1 - a[[i, 0, kc]];
-                b[[i, kc, 1]] = a[[i, 0, kc]] + y1;
-            }
-        }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[0, k - 1]];
-            s1k = sine[[0, k - 1]];
-            for i in 0..nv {
-                x1 = c1k * a[[i, 1, k]] - s1k * a[[i, 1, kc]];
-                y1 = c1k * a[[i, 1, kc]] + s1k * a[[i, 1, k]];
-                b[[i, k, 0]] = a[[i, 0, k]] + x1;
-                b[[i, kc, 0]] = a[[i, 0, k]] - x1;
-                b[[i, k, 1]] = y1 - a[[i, 0, kc]];
-                b[[i, kc, 1]] = a[[i, 0, kc]] + y1;
+                c1k = cosine[[0, k - 1]];
+                s1k = sine[[0, k - 1]];
+                for i in 0..nv {
+                    x1 = c1k * a.uget((i, 1, k)) - s1k * a.uget((i, 1, kc));
+                    y1 = c1k * a.uget((i, 1, kc)) + s1k * a.uget((i, 1, k));
+                    *b.uget_mut((i, k, 0)) = a.uget((i, 0, k)) + x1;
+                    *b.uget_mut((i, kc, 0)) = a.uget((i, 0, k)) - x1;
+                    *b.uget_mut((i, k, 1)) = y1 - a.uget((i, 0, kc));
+                    *b.uget_mut((i, kc, 1)) = a.uget((i, 0, kc)) + y1;
+                }
             }
         }
     }

--- a/shallow_water/src/stafft/reverse.rs
+++ b/shallow_water/src/stafft/reverse.rs
@@ -75,158 +75,160 @@ pub fn revrdx6(
 
     let mut kc: usize;
 
-    //Do k=0 first:
-    for i in 0..nv {
-        t2r = a[[i, 0, 0]] - 0.5 * a[[i, 0, 2]];
-        t3r = SINFPI3 * a[[i, 0, 4]];
-        u0r = a[[i, 0, 0]] + a[[i, 0, 2]];
-        u1r = t2r + t3r;
-        u2r = t2r - t3r;
-        t2i = a[[i, 0, 3]] - 0.5 * a[[i, 0, 1]];
-        t3i = -SINFPI3 * a[[i, 0, 5]];
-        v0r = a[[i, 0, 3]] + a[[i, 0, 1]];
-        v1r = t2i + t3i;
-        v2r = t2i - t3i;
-        b[[i, 0, 0]] = u0r + v0r;
-        b[[i, 1, 0]] = u1r - v1r;
-        b[[i, 2, 0]] = u2r + v2r;
-        b[[i, 3, 0]] = u0r - v0r;
-        b[[i, 4, 0]] = u1r + v1r;
-        b[[i, 5, 0]] = u2r - v2r;
-    }
-    //Next do remaining k:
-    if nv <= (lv - 1) / 2 {
+    unsafe {
+        //Do k=0 first:
         for i in 0..nv {
+            t2r = a.uget((i, 0, 0)) - 0.5 * a.uget((i, 0, 2));
+            t3r = SINFPI3 * a.uget((i, 0, 4));
+            u0r = a.uget((i, 0, 0)) + a.uget((i, 0, 2));
+            u1r = t2r + t3r;
+            u2r = t2r - t3r;
+            t2i = a.uget((i, 0, 3)) - 0.5 * a.uget((i, 0, 1));
+            t3i = -SINFPI3 * a.uget((i, 0, 5));
+            v0r = a.uget((i, 0, 3)) + a.uget((i, 0, 1));
+            v1r = t2i + t3i;
+            v2r = t2i - t3i;
+            *b.uget_mut((i, 0, 0)) = u0r + v0r;
+            *b.uget_mut((i, 1, 0)) = u1r - v1r;
+            *b.uget_mut((i, 2, 0)) = u2r + v2r;
+            *b.uget_mut((i, 3, 0)) = u0r - v0r;
+            *b.uget_mut((i, 4, 0)) = u1r + v1r;
+            *b.uget_mut((i, 5, 0)) = u2r - v2r;
+        }
+        //Next do remaining k:
+        if nv <= (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+                    t1r = a.uget((i, k, 2)) + a.uget((i, kc, 1));
+                    t1i = a.uget((i, kc, 3)) - a.uget((i, k, 4));
+                    t2r = a.uget((i, k, 0)) - 0.5 * t1r;
+                    t2i = a.uget((i, kc, 5)) - 0.5 * t1i;
+                    t3r = SINFPI3 * (a.uget((i, k, 2)) - a.uget((i, kc, 1)));
+                    t3i = SINFPI3 * (a.uget((i, kc, 3)) + a.uget((i, k, 4)));
+                    u0r = a.uget((i, k, 0)) + t1r;
+                    u0i = a.uget((i, kc, 5)) + t1i;
+                    u1r = t2r + t3i;
+                    u1i = t2i - t3r;
+                    u2r = t2r - t3i;
+                    u2i = t2i + t3r;
+                    t1r = a.uget((i, kc, 0)) + a.uget((i, k, 1));
+                    t1i = a.uget((i, kc, 4)) - a.uget((i, k, 5));
+                    t2r = a.uget((i, kc, 2)) - 0.5 * t1r;
+                    t2i = -a.uget((i, k, 3)) - 0.5 * t1i;
+                    t3r = SINFPI3 * (a.uget((i, kc, 0)) - a.uget((i, k, 1)));
+                    t3i = SINFPI3 * (-a.uget((i, k, 5)) - a.uget((i, kc, 4)));
+                    v0r = a.uget((i, kc, 2)) + t1r;
+                    v0i = t1i - a.uget((i, k, 3));
+                    v1r = t2r + t3i;
+                    v1i = t2i - t3r;
+                    v2r = t2r - t3i;
+                    v2i = t2i + t3r;
+                    x1p = u1r - v1r;
+                    y1p = u1i - v1i;
+                    x2p = u2r + v2r;
+                    y2p = u2i + v2i;
+                    x3p = u0r - v0r;
+                    y3p = u0i - v0i;
+                    x4p = u1r + v1r;
+                    y4p = u1i + v1i;
+                    x5p = u2r - v2r;
+                    y5p = u2i - v2i;
+                    *b.uget_mut((i, 0, k)) = u0r + v0r;
+                    *b.uget_mut((i, 0, kc)) = u0i + v0i;
+                    *b.uget_mut((i, 1, k)) = cosine.uget((k, 0)) * x1p - sine.uget((k, 0)) * y1p;
+                    *b.uget_mut((i, 1, kc)) = cosine.uget((k, 0)) * y1p + sine.uget((k, 0)) * x1p;
+                    *b.uget_mut((i, 2, k)) = cosine.uget((k, 1)) * x2p - sine.uget((k, 1)) * y2p;
+                    *b.uget_mut((i, 2, kc)) = cosine.uget((k, 1)) * y2p + sine.uget((k, 1)) * x2p;
+                    *b.uget_mut((i, 3, k)) = cosine.uget((k, 2)) * x3p - sine.uget((k, 2)) * y3p;
+                    *b.uget_mut((i, 3, kc)) = cosine.uget((k, 2)) * y3p + sine.uget((k, 2)) * x3p;
+                    *b.uget_mut((i, 4, k)) = cosine.uget((k, 4)) * x4p - sine.uget((k, 4)) * y4p;
+                    *b.uget_mut((i, 4, kc)) = cosine.uget((k, 4)) * y4p + sine.uget((k, 4)) * x4p;
+                    *b.uget_mut((i, 5, k)) = cosine.uget((k, 5)) * x5p - sine.uget((k, 5)) * y5p;
+                    *b.uget_mut((i, 5, kc)) = cosine.uget((k, 5)) * y5p + sine.uget((k, 5)) * x5p;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
-                t1r = a[[i, k, 2]] + a[[i, kc, 1]];
-                t1i = a[[i, kc, 3]] - a[[i, k, 4]];
-                t2r = a[[i, k, 0]] - 0.5 * t1r;
-                t2i = a[[i, kc, 5]] - 0.5 * t1i;
-                t3r = SINFPI3 * (a[[i, k, 2]] - a[[i, kc, 1]]);
-                t3i = SINFPI3 * (a[[i, kc, 3]] + a[[i, k, 4]]);
-                u0r = a[[i, k, 0]] + t1r;
-                u0i = a[[i, kc, 5]] + t1i;
-                u1r = t2r + t3i;
-                u1i = t2i - t3r;
-                u2r = t2r - t3i;
-                u2i = t2i + t3r;
-                t1r = a[[i, kc, 0]] + a[[i, k, 1]];
-                t1i = a[[i, kc, 4]] - a[[i, k, 5]];
-                t2r = a[[i, kc, 2]] - 0.5 * t1r;
-                t2i = -a[[i, k, 3]] - 0.5 * t1i;
-                t3r = SINFPI3 * (a[[i, kc, 0]] - a[[i, k, 1]]);
-                t3i = SINFPI3 * (-a[[i, k, 5]] - a[[i, kc, 4]]);
-                v0r = a[[i, kc, 2]] + t1r;
-                v0i = t1i - a[[i, k, 3]];
-                v1r = t2r + t3i;
-                v1i = t2i - t3r;
-                v2r = t2r - t3i;
-                v2i = t2i + t3r;
-                x1p = u1r - v1r;
-                y1p = u1i - v1i;
-                x2p = u2r + v2r;
-                y2p = u2i + v2i;
-                x3p = u0r - v0r;
-                y3p = u0i - v0i;
-                x4p = u1r + v1r;
-                y4p = u1i + v1i;
-                x5p = u2r - v2r;
-                y5p = u2i - v2i;
-                b[[i, 0, k]] = u0r + v0r;
-                b[[i, 0, kc]] = u0i + v0i;
-                b[[i, 1, k]] = cosine[[k, 0]] * x1p - sine[[k, 0]] * y1p;
-                b[[i, 1, kc]] = cosine[[k, 0]] * y1p + sine[[k, 0]] * x1p;
-                b[[i, 2, k]] = cosine[[k, 1]] * x2p - sine[[k, 1]] * y2p;
-                b[[i, 2, kc]] = cosine[[k, 1]] * y2p + sine[[k, 1]] * x2p;
-                b[[i, 3, k]] = cosine[[k, 2]] * x3p - sine[[k, 2]] * y3p;
-                b[[i, 3, kc]] = cosine[[k, 2]] * y3p + sine[[k, 2]] * x3p;
-                b[[i, 4, k]] = cosine[[k, 4]] * x4p - sine[[k, 4]] * y4p;
-                b[[i, 4, kc]] = cosine[[k, 4]] * y4p + sine[[k, 4]] * x4p;
-                b[[i, 5, k]] = cosine[[k, 5]] * x5p - sine[[k, 5]] * y5p;
-                b[[i, 5, kc]] = cosine[[k, 5]] * y5p + sine[[k, 5]] * x5p;
+                c1k = *cosine.uget((k, 0));
+                s1k = *sine.uget((k, 0));
+                c2k = *cosine.uget((k, 1));
+                s2k = *sine.uget((k, 1));
+                c3k = *cosine.uget((k, 2));
+                s3k = *sine.uget((k, 2));
+                c4k = *cosine.uget((k, 3));
+                s4k = *sine.uget((k, 3));
+                c5k = *cosine.uget((k, 4));
+                s5k = *sine.uget((k, 4));
+                for i in 0..nv {
+                    t1r = a.uget((i, k, 2)) + a.uget((i, kc, 1));
+                    t1i = a.uget((i, kc, 3)) - a.uget((i, k, 4));
+                    t2r = a.uget((i, k, 0)) - 0.5 * t1r;
+                    t2i = a.uget((i, kc, 5)) - 0.5 * t1i;
+                    t3r = SINFPI3 * (a.uget((i, k, 2)) - a.uget((i, kc, 1)));
+                    t3i = SINFPI3 * (a.uget((i, kc, 3)) + a.uget((i, k, 4)));
+                    u0r = a.uget((i, k, 0)) + t1r;
+                    u0i = a.uget((i, kc, 5)) + t1i;
+                    u1r = t2r + t3i;
+                    u1i = t2i - t3r;
+                    u2r = t2r - t3i;
+                    u2i = t2i + t3r;
+                    t1r = a.uget((i, kc, 0)) + a.uget((i, k, 1));
+                    t1i = a.uget((i, kc, 4)) - a.uget((i, k, 5));
+                    t2r = a.uget((i, kc, 2)) - 0.5 * t1r;
+                    t2i = -a.uget((i, k, 3)) - 0.5 * t1i;
+                    t3r = SINFPI3 * (a.uget((i, kc, 0)) - a.uget((i, k, 1)));
+                    t3i = SINFPI3 * (-a.uget((i, k, 5)) - a.uget((i, kc, 4)));
+                    v0r = a.uget((i, kc, 2)) + t1r;
+                    v0i = t1i - a.uget((i, k, 3));
+                    v1r = t2r + t3i;
+                    v1i = t2i - t3r;
+                    v2r = t2r - t3i;
+                    v2i = t2i + t3r;
+                    x1p = u1r - v1r;
+                    y1p = u1i - v1i;
+                    x2p = u2r + v2r;
+                    y2p = u2i + v2i;
+                    x3p = u0r - v0r;
+                    y3p = u0i - v0i;
+                    x4p = u1r + v1r;
+                    y4p = u1i + v1i;
+                    x5p = u2r - v2r;
+                    y5p = u2i - v2i;
+                    *b.uget_mut((i, 0, k)) = u0r + v0r;
+                    *b.uget_mut((i, 0, kc)) = u0i + v0i;
+                    *b.uget_mut((i, 1, k)) = c1k * x1p - s1k * y1p;
+                    *b.uget_mut((i, 1, kc)) = c1k * y1p + s1k * x1p;
+                    *b.uget_mut((i, 2, k)) = c2k * x2p - s2k * y2p;
+                    *b.uget_mut((i, 2, kc)) = c2k * y2p + s2k * x2p;
+                    *b.uget_mut((i, 3, k)) = c3k * x3p - s3k * y3p;
+                    *b.uget_mut((i, 3, kc)) = c3k * y3p + s3k * x3p;
+                    *b.uget_mut((i, 4, k)) = c4k * x4p - s4k * y4p;
+                    *b.uget_mut((i, 4, kc)) = c4k * y4p + s4k * x4p;
+                    *b.uget_mut((i, 5, k)) = c5k * x5p - s5k * y5p;
+                    *b.uget_mut((i, 5, kc)) = c5k * y5p + s5k * x5p;
+                }
             }
         }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[k, 0]];
-            s1k = sine[[k, 0]];
-            c2k = cosine[[k, 1]];
-            s2k = sine[[k, 1]];
-            c3k = cosine[[k, 2]];
-            s3k = sine[[k, 2]];
-            c4k = cosine[[k, 3]];
-            s4k = sine[[k, 3]];
-            c5k = cosine[[k, 4]];
-            s5k = sine[[k, 4]];
-            for i in 0..nv {
-                t1r = a[[i, k, 2]] + a[[i, kc, 1]];
-                t1i = a[[i, kc, 3]] - a[[i, k, 4]];
-                t2r = a[[i, k, 0]] - 0.5 * t1r;
-                t2i = a[[i, kc, 5]] - 0.5 * t1i;
-                t3r = SINFPI3 * (a[[i, k, 2]] - a[[i, kc, 1]]);
-                t3i = SINFPI3 * (a[[i, kc, 3]] + a[[i, k, 4]]);
-                u0r = a[[i, k, 0]] + t1r;
-                u0i = a[[i, kc, 5]] + t1i;
-                u1r = t2r + t3i;
-                u1i = t2i - t3r;
-                u2r = t2r - t3i;
-                u2i = t2i + t3r;
-                t1r = a[[i, kc, 0]] + a[[i, k, 1]];
-                t1i = a[[i, kc, 4]] - a[[i, k, 5]];
-                t2r = a[[i, kc, 2]] - 0.5 * t1r;
-                t2i = -a[[i, k, 3]] - 0.5 * t1i;
-                t3r = SINFPI3 * (a[[i, kc, 0]] - a[[i, k, 1]]);
-                t3i = SINFPI3 * (-a[[i, k, 5]] - a[[i, kc, 4]]);
-                v0r = a[[i, kc, 2]] + t1r;
-                v0i = t1i - a[[i, k, 3]];
-                v1r = t2r + t3i;
-                v1i = t2i - t3r;
-                v2r = t2r - t3i;
-                v2i = t2i + t3r;
-                x1p = u1r - v1r;
-                y1p = u1i - v1i;
-                x2p = u2r + v2r;
-                y2p = u2i + v2i;
-                x3p = u0r - v0r;
-                y3p = u0i - v0i;
-                x4p = u1r + v1r;
-                y4p = u1i + v1i;
-                x5p = u2r - v2r;
-                y5p = u2i - v2i;
-                b[[i, 0, k]] = u0r + v0r;
-                b[[i, 0, kc]] = u0i + v0i;
-                b[[i, 1, k]] = c1k * x1p - s1k * y1p;
-                b[[i, 1, kc]] = c1k * y1p + s1k * x1p;
-                b[[i, 2, k]] = c2k * x2p - s2k * y2p;
-                b[[i, 2, kc]] = c2k * y2p + s2k * x2p;
-                b[[i, 3, k]] = c3k * x3p - s3k * y3p;
-                b[[i, 3, kc]] = c3k * y3p + s3k * x3p;
-                b[[i, 4, k]] = c4k * x4p - s4k * y4p;
-                b[[i, 4, kc]] = c4k * y4p + s4k * x4p;
-                b[[i, 5, k]] = c5k * x5p - s5k * y5p;
-                b[[i, 5, kc]] = c5k * y5p + s5k * x5p;
-            }
-        }
-    }
 
-    //Catch the case k=lv/2 when lv even:
-    if lv % 2 == 0 {
-        let lvd2 = lv / 2;
-        for i in 0..nv {
-            q1 = a[[i, lvd2, 0]] + a[[i, lvd2, 2]];
-            q2 = a[[i, lvd2, 5]] + a[[i, lvd2, 3]];
-            q3 = a[[i, lvd2, 1]] - 0.5 * q1;
-            q4 = a[[i, lvd2, 4]] + 0.5 * q2;
-            q5 = SINFPI3 * (a[[i, lvd2, 0]] - a[[i, lvd2, 2]]);
-            q6 = SINFPI3 * (a[[i, lvd2, 5]] - a[[i, lvd2, 3]]);
-            b[[i, 0, lvd2]] = a[[i, lvd2, 1]] + q1;
-            b[[i, 1, lvd2]] = q4 + q5;
-            b[[i, 2, lvd2]] = q6 - q3;
-            b[[i, 3, lvd2]] = q2 - a[[i, lvd2, 4]];
-            b[[i, 4, lvd2]] = q3 + q6;
-            b[[i, 5, lvd2]] = q4 - q5;
+        //Catch the case k=lv/2 when lv even:
+        if lv % 2 == 0 {
+            let lvd2 = lv / 2;
+            for i in 0..nv {
+                q1 = a.uget((i, lvd2, 0)) + a.uget((i, lvd2, 2));
+                q2 = a.uget((i, lvd2, 5)) + a.uget((i, lvd2, 3));
+                q3 = a.uget((i, lvd2, 1)) - 0.5 * q1;
+                q4 = a.uget((i, lvd2, 4)) + 0.5 * q2;
+                q5 = SINFPI3 * (a.uget((i, lvd2, 0)) - a.uget((i, lvd2, 2)));
+                q6 = SINFPI3 * (a.uget((i, lvd2, 5)) - a.uget((i, lvd2, 3)));
+                *b.uget_mut((i, 0, lvd2)) = a.uget((i, lvd2, 1)) + q1;
+                *b.uget_mut((i, 1, lvd2)) = q4 + q5;
+                *b.uget_mut((i, 2, lvd2)) = q6 - q3;
+                *b.uget_mut((i, 3, lvd2)) = q2 - a.uget((i, lvd2, 4));
+                *b.uget_mut((i, 4, lvd2)) = q3 + q6;
+                *b.uget_mut((i, 5, lvd2)) = q4 - q5;
+            }
         }
     }
 }
@@ -295,122 +297,124 @@ pub fn revrdx5(
 
     let mut kc: usize;
 
-    //Do k=0 first:
-    for i in 0..nv {
-        t3r = SINF2PI5 * a[[i, 0, 4]];
-        t4r = SINF2PI5 * a[[i, 0, 3]];
-        t5r = a[[i, 0, 1]] + a[[i, 0, 2]];
-        t6r = RTF516 * (a[[i, 0, 1]] - a[[i, 0, 2]]);
-        t7r = a[[i, 0, 0]] - 0.25 * t5r;
-        t8r = t7r + t6r;
-        t9r = t7r - t6r;
-        t10r = t3r + SINRAT * t4r;
-        t11r = SINRAT * t3r - t4r;
-        b[[i, 0, 0]] = a[[i, 0, 0]] + t5r;
-        b[[i, 1, 0]] = t8r + t10r;
-        b[[i, 2, 0]] = t9r + t11r;
-        b[[i, 3, 0]] = t9r - t11r;
-        b[[i, 4, 0]] = t8r - t10r;
-    }
-    //Next do remaining k:
-    if nv <= (lv - 1) / 2 {
+    unsafe {
+        //Do k=0 first:
         for i in 0..nv {
+            t3r = SINF2PI5 * a.uget((i, 0, 4));
+            t4r = SINF2PI5 * a.uget((i, 0, 3));
+            t5r = a.uget((i, 0, 1)) + a.uget((i, 0, 2));
+            t6r = RTF516 * (a.uget((i, 0, 1)) - a.uget((i, 0, 2)));
+            t7r = a.uget((i, 0, 0)) - 0.25 * t5r;
+            t8r = t7r + t6r;
+            t9r = t7r - t6r;
+            t10r = t3r + SINRAT * t4r;
+            t11r = SINRAT * t3r - t4r;
+            *b.uget_mut((i, 0, 0)) = a.uget((i, 0, 0)) + t5r;
+            *b.uget_mut((i, 1, 0)) = t8r + t10r;
+            *b.uget_mut((i, 2, 0)) = t9r + t11r;
+            *b.uget_mut((i, 3, 0)) = t9r - t11r;
+            *b.uget_mut((i, 4, 0)) = t8r - t10r;
+        }
+        //Next do remaining k:
+        if nv <= (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+                    t1r = a.uget((i, k, 1)) + a.uget((i, kc, 0));
+                    t1i = a.uget((i, kc, 3)) - a.uget((i, k, 4));
+                    t2r = a.uget((i, k, 2)) + a.uget((i, kc, 1));
+                    t2i = a.uget((i, kc, 2)) - a.uget((i, k, 3));
+                    t3r = SINF2PI5 * (a.uget((i, k, 1)) - a.uget((i, kc, 0)));
+                    t3i = SINF2PI5 * (a.uget((i, kc, 3)) + a.uget((i, k, 4)));
+                    t4r = SINF2PI5 * (a.uget((i, k, 2)) - a.uget((i, kc, 1)));
+                    t4i = SINF2PI5 * (a.uget((i, kc, 2)) + a.uget((i, k, 3)));
+                    t5r = t1r + t2r;
+                    t5i = t1i + t2i;
+                    t6r = RTF516 * (t1r - t2r);
+                    t6i = RTF516 * (t1i - t2i);
+                    t7r = a.uget((i, k, 0)) - 0.25 * t5r;
+                    t7i = a.uget((i, kc, 4)) - 0.25 * t5i;
+                    t8r = t7r + t6r;
+                    t8i = t7i + t6i;
+                    t9r = t7r - t6r;
+                    t9i = t7i - t6i;
+                    t10r = t3r + SINRAT * t4r;
+                    t10i = t3i + SINRAT * t4i;
+                    t11r = SINRAT * t3r - t4r;
+                    t11i = SINRAT * t3i - t4i;
+                    x1p = t8r + t10i;
+                    y1p = t8i - t10r;
+                    x2p = t9r + t11i;
+                    y2p = t9i - t11r;
+                    x3p = t9r - t11i;
+                    y3p = t9i + t11r;
+                    x4p = t8r - t10i;
+                    y4p = t8i + t10r;
+                    *b.uget_mut((i, 0, k)) = a.uget((i, k, 0)) + t5r;
+                    *b.uget_mut((i, 0, kc)) = a.uget((i, kc, 4)) + t5i;
+                    *b.uget_mut((i, 1, k)) = cosine.uget((k, 0)) * x1p - sine.uget((k, 0)) * y1p;
+                    *b.uget_mut((i, 1, kc)) = cosine.uget((k, 0)) * y1p + sine.uget((k, 0)) * x1p;
+                    *b.uget_mut((i, 2, k)) = cosine.uget((k, 1)) * x2p - sine.uget((k, 1)) * y2p;
+                    *b.uget_mut((i, 2, kc)) = cosine.uget((k, 1)) * y2p + sine.uget((k, 1)) * x2p;
+                    *b.uget_mut((i, 3, k)) = cosine.uget((k, 2)) * x3p - sine.uget((k, 2)) * y3p;
+                    *b.uget_mut((i, 3, kc)) = cosine.uget((k, 2)) * y3p + sine.uget((k, 2)) * x3p;
+                    *b.uget_mut((i, 4, k)) = cosine.uget((k, 4)) * x4p - sine.uget((k, 4)) * y4p;
+                    *b.uget_mut((i, 4, kc)) = cosine.uget((k, 4)) * y4p + sine.uget((k, 4)) * x4p;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
-                t1r = a[[i, k, 1]] + a[[i, kc, 0]];
-                t1i = a[[i, kc, 3]] - a[[i, k, 4]];
-                t2r = a[[i, k, 2]] + a[[i, kc, 1]];
-                t2i = a[[i, kc, 2]] - a[[i, k, 3]];
-                t3r = SINF2PI5 * (a[[i, k, 1]] - a[[i, kc, 0]]);
-                t3i = SINF2PI5 * (a[[i, kc, 3]] + a[[i, k, 4]]);
-                t4r = SINF2PI5 * (a[[i, k, 2]] - a[[i, kc, 1]]);
-                t4i = SINF2PI5 * (a[[i, kc, 2]] + a[[i, k, 3]]);
-                t5r = t1r + t2r;
-                t5i = t1i + t2i;
-                t6r = RTF516 * (t1r - t2r);
-                t6i = RTF516 * (t1i - t2i);
-                t7r = a[[i, k, 0]] - 0.25 * t5r;
-                t7i = a[[i, kc, 4]] - 0.25 * t5i;
-                t8r = t7r + t6r;
-                t8i = t7i + t6i;
-                t9r = t7r - t6r;
-                t9i = t7i - t6i;
-                t10r = t3r + SINRAT * t4r;
-                t10i = t3i + SINRAT * t4i;
-                t11r = SINRAT * t3r - t4r;
-                t11i = SINRAT * t3i - t4i;
-                x1p = t8r + t10i;
-                y1p = t8i - t10r;
-                x2p = t9r + t11i;
-                y2p = t9i - t11r;
-                x3p = t9r - t11i;
-                y3p = t9i + t11r;
-                x4p = t8r - t10i;
-                y4p = t8i + t10r;
-                b[[i, 0, k]] = a[[i, k, 0]] + t5r;
-                b[[i, 0, kc]] = a[[i, kc, 4]] + t5i;
-                b[[i, 1, k]] = cosine[[k, 0]] * x1p - sine[[k, 0]] * y1p;
-                b[[i, 1, kc]] = cosine[[k, 0]] * y1p + sine[[k, 0]] * x1p;
-                b[[i, 2, k]] = cosine[[k, 1]] * x2p - sine[[k, 1]] * y2p;
-                b[[i, 2, kc]] = cosine[[k, 1]] * y2p + sine[[k, 1]] * x2p;
-                b[[i, 3, k]] = cosine[[k, 2]] * x3p - sine[[k, 2]] * y3p;
-                b[[i, 3, kc]] = cosine[[k, 2]] * y3p + sine[[k, 2]] * x3p;
-                b[[i, 4, k]] = cosine[[k, 4]] * x4p - sine[[k, 4]] * y4p;
-                b[[i, 4, kc]] = cosine[[k, 4]] * y4p + sine[[k, 4]] * x4p;
-            }
-        }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[k, 0]];
-            s1k = sine[[k, 0]];
-            c2k = cosine[[k, 1]];
-            s2k = sine[[k, 1]];
-            c3k = cosine[[k, 2]];
-            s3k = sine[[k, 2]];
-            c4k = cosine[[k, 4]];
-            s4k = sine[[k, 4]];
-            for i in 0..nv {
-                t1r = a[[i, k, 1]] + a[[i, kc, 0]];
-                t1i = a[[i, kc, 3]] - a[[i, k, 4]];
-                t2r = a[[i, k, 2]] + a[[i, kc, 1]];
-                t2i = a[[i, kc, 2]] - a[[i, k, 3]];
-                t3r = SINF2PI5 * (a[[i, k, 1]] - a[[i, kc, 0]]);
-                t3i = SINF2PI5 * (a[[i, kc, 3]] + a[[i, k, 4]]);
-                t4r = SINF2PI5 * (a[[i, k, 2]] - a[[i, kc, 1]]);
-                t4i = SINF2PI5 * (a[[i, kc, 2]] + a[[i, k, 3]]);
-                t5r = t1r + t2r;
-                t5i = t1i + t2i;
-                t6r = RTF516 * (t1r - t2r);
-                t6i = RTF516 * (t1i - t2i);
-                t7r = a[[i, k, 0]] - 0.25 * t5r;
-                t7i = a[[i, kc, 4]] - 0.25 * t5i;
-                t8r = t7r + t6r;
-                t8i = t7i + t6i;
-                t9r = t7r - t6r;
-                t9i = t7i - t6i;
-                t10r = t3r + SINRAT * t4r;
-                t10i = t3i + SINRAT * t4i;
-                t11r = SINRAT * t3r - t4r;
-                t11i = SINRAT * t3i - t4i;
-                x1p = t8r + t10i;
-                y1p = t8i - t10r;
-                x2p = t9r + t11i;
-                y2p = t9i - t11r;
-                x3p = t9r - t11i;
-                y3p = t9i + t11r;
-                x4p = t8r - t10i;
-                y4p = t8i + t10r;
-                b[[i, 0, k]] = a[[i, k, 0]] + t5r;
-                b[[i, 0, kc]] = a[[i, kc, 4]] + t5i;
-                b[[i, 1, k]] = c1k * x1p - s1k * y1p;
-                b[[i, 1, kc]] = c1k * y1p + s1k * x1p;
-                b[[i, 2, k]] = c2k * x2p - s2k * y2p;
-                b[[i, 2, kc]] = c2k * y2p + s2k * x2p;
-                b[[i, 3, k]] = c3k * x3p - s3k * y3p;
-                b[[i, 3, kc]] = c3k * y3p + s3k * x3p;
-                b[[i, 4, k]] = c4k * x4p - s4k * y4p;
-                b[[i, 4, kc]] = c4k * y4p + s4k * x4p;
+                c1k = *cosine.uget((k, 0));
+                s1k = *sine.uget((k, 0));
+                c2k = *cosine.uget((k, 1));
+                s2k = *sine.uget((k, 1));
+                c3k = *cosine.uget((k, 2));
+                s3k = *sine.uget((k, 2));
+                c4k = *cosine.uget((k, 4));
+                s4k = *sine.uget((k, 4));
+                for i in 0..nv {
+                    t1r = a.uget((i, k, 1)) + a.uget((i, kc, 0));
+                    t1i = a.uget((i, kc, 3)) - a.uget((i, k, 4));
+                    t2r = a.uget((i, k, 2)) + a.uget((i, kc, 1));
+                    t2i = a.uget((i, kc, 2)) - a.uget((i, k, 3));
+                    t3r = SINF2PI5 * (a.uget((i, k, 1)) - a.uget((i, kc, 0)));
+                    t3i = SINF2PI5 * (a.uget((i, kc, 3)) + a.uget((i, k, 4)));
+                    t4r = SINF2PI5 * (a.uget((i, k, 2)) - a.uget((i, kc, 1)));
+                    t4i = SINF2PI5 * (a.uget((i, kc, 2)) + a.uget((i, k, 3)));
+                    t5r = t1r + t2r;
+                    t5i = t1i + t2i;
+                    t6r = RTF516 * (t1r - t2r);
+                    t6i = RTF516 * (t1i - t2i);
+                    t7r = a.uget((i, k, 0)) - 0.25 * t5r;
+                    t7i = a.uget((i, kc, 4)) - 0.25 * t5i;
+                    t8r = t7r + t6r;
+                    t8i = t7i + t6i;
+                    t9r = t7r - t6r;
+                    t9i = t7i - t6i;
+                    t10r = t3r + SINRAT * t4r;
+                    t10i = t3i + SINRAT * t4i;
+                    t11r = SINRAT * t3r - t4r;
+                    t11i = SINRAT * t3i - t4i;
+                    x1p = t8r + t10i;
+                    y1p = t8i - t10r;
+                    x2p = t9r + t11i;
+                    y2p = t9i - t11r;
+                    x3p = t9r - t11i;
+                    y3p = t9i + t11r;
+                    x4p = t8r - t10i;
+                    y4p = t8i + t10r;
+                    *b.uget_mut((i, 0, k)) = a.uget((i, k, 0)) + t5r;
+                    *b.uget_mut((i, 0, kc)) = a.uget((i, kc, 4)) + t5i;
+                    *b.uget_mut((i, 1, k)) = c1k * x1p - s1k * y1p;
+                    *b.uget_mut((i, 1, kc)) = c1k * y1p + s1k * x1p;
+                    *b.uget_mut((i, 2, k)) = c2k * x2p - s2k * y2p;
+                    *b.uget_mut((i, 2, kc)) = c2k * y2p + s2k * x2p;
+                    *b.uget_mut((i, 3, k)) = c3k * x3p - s3k * y3p;
+                    *b.uget_mut((i, 3, kc)) = c3k * y3p + s3k * x3p;
+                    *b.uget_mut((i, 4, k)) = c4k * x4p - s4k * y4p;
+                    *b.uget_mut((i, 4, kc)) = c4k * y4p + s4k * x4p;
+                }
             }
         }
     }
@@ -462,92 +466,94 @@ pub fn revrdx4(
 
     let mut kc: usize;
 
-    //Do k=0 first:
-    for i in 0..nv {
-        t1r = a[[i, 0, 0]] + a[[i, 0, 2]];
-        t2r = a[[i, 0, 1]];
-        t3r = a[[i, 0, 0]] - a[[i, 0, 2]];
-        t4r = a[[i, 0, 3]];
-        b[[i, 0, 0]] = t1r + t2r;
-        b[[i, 1, 0]] = t3r + t4r;
-        b[[i, 2, 0]] = t1r - t2r;
-        b[[i, 3, 0]] = t3r - t4r;
-    }
-    //Next do remaining k:
-    if nv < (lv - 1) / 2 {
+    unsafe {
+        //Do k=0 first:
         for i in 0..nv {
+            t1r = a.uget((i, 0, 0)) + a.uget((i, 0, 2));
+            t2r = *a.uget((i, 0, 1));
+            t3r = a.uget((i, 0, 0)) - a.uget((i, 0, 2));
+            t4r = *a.uget((i, 0, 3));
+            *b.uget_mut((i, 0, 0)) = t1r + t2r;
+            *b.uget_mut((i, 1, 0)) = t3r + t4r;
+            *b.uget_mut((i, 2, 0)) = t1r - t2r;
+            *b.uget_mut((i, 3, 0)) = t3r - t4r;
+        }
+        //Next do remaining k:
+        if nv < (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+                    t1r = a.uget((i, k, 0)) + a.uget((i, kc, 1));
+                    t1i = a.uget((i, kc, 3)) - a.uget((i, k, 2));
+                    t2r = a.uget((i, k, 1)) + a.uget((i, kc, 0));
+                    t2i = a.uget((i, kc, 2)) - a.uget((i, k, 3));
+                    t3r = a.uget((i, k, 0)) - a.uget((i, kc, 1));
+                    t3i = a.uget((i, kc, 3)) + a.uget((i, k, 2));
+                    t4r = a.uget((i, k, 1)) - a.uget((i, kc, 0));
+                    t4i = a.uget((i, kc, 2)) + a.uget((i, k, 3));
+                    x1p = t3r + t4i;
+                    y1p = t3i - t4r;
+                    x2p = t1r - t2r;
+                    y2p = t1i - t2i;
+                    x3p = t3r - t4i;
+                    y3p = t3i + t4r;
+                    *b.uget_mut((i, 0, k)) = t1r + t2r;
+                    *b.uget_mut((i, 0, kc)) = t1i + t2i;
+                    *b.uget_mut((i, 1, k)) = cosine.uget((k, 0)) * x1p - sine.uget((k, 0)) * y1p;
+                    *b.uget_mut((i, 1, kc)) = cosine.uget((k, 0)) * y1p + sine.uget((k, 0)) * x1p;
+                    *b.uget_mut((i, 2, k)) = cosine.uget((k, 1)) * x2p - sine.uget((k, 1)) * y2p;
+                    *b.uget_mut((i, 2, kc)) = cosine.uget((k, 1)) * y2p + sine.uget((k, 1)) * x2p;
+                    *b.uget_mut((i, 3, k)) = cosine.uget((k, 2)) * x3p - sine.uget((k, 2)) * y3p;
+                    *b.uget_mut((i, 3, kc)) = cosine.uget((k, 2)) * y3p + sine.uget((k, 2)) * x3p;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
-                t1r = a[[i, k, 0]] + a[[i, kc, 1]];
-                t1i = a[[i, kc, 3]] - a[[i, k, 2]];
-                t2r = a[[i, k, 1]] + a[[i, kc, 0]];
-                t2i = a[[i, kc, 2]] - a[[i, k, 3]];
-                t3r = a[[i, k, 0]] - a[[i, kc, 1]];
-                t3i = a[[i, kc, 3]] + a[[i, k, 2]];
-                t4r = a[[i, k, 1]] - a[[i, kc, 0]];
-                t4i = a[[i, kc, 2]] + a[[i, k, 3]];
-                x1p = t3r + t4i;
-                y1p = t3i - t4r;
-                x2p = t1r - t2r;
-                y2p = t1i - t2i;
-                x3p = t3r - t4i;
-                y3p = t3i + t4r;
-                b[[i, 0, k]] = t1r + t2r;
-                b[[i, 0, kc]] = t1i + t2i;
-                b[[i, 1, k]] = cosine[[k, 0]] * x1p - sine[[k, 0]] * y1p;
-                b[[i, 1, kc]] = cosine[[k, 0]] * y1p + sine[[k, 0]] * x1p;
-                b[[i, 2, k]] = cosine[[k, 1]] * x2p - sine[[k, 1]] * y2p;
-                b[[i, 2, kc]] = cosine[[k, 1]] * y2p + sine[[k, 1]] * x2p;
-                b[[i, 3, k]] = cosine[[k, 2]] * x3p - sine[[k, 2]] * y3p;
-                b[[i, 3, kc]] = cosine[[k, 2]] * y3p + sine[[k, 2]] * x3p;
+                c1k = *cosine.uget((k, 0));
+                s1k = *sine.uget((k, 0));
+                c2k = *cosine.uget((k, 1));
+                s2k = *sine.uget((k, 1));
+                c3k = *cosine.uget((k, 2));
+                s3k = *sine.uget((k, 2));
+                for i in 0..nv {
+                    t1r = a.uget((i, k, 0)) + a.uget((i, kc, 1));
+                    t1i = a.uget((i, kc, 3)) - a.uget((i, k, 2));
+                    t2r = a.uget((i, k, 1)) + a.uget((i, kc, 0));
+                    t2i = a.uget((i, kc, 2)) - a.uget((i, k, 3));
+                    t3r = a.uget((i, k, 0)) - a.uget((i, kc, 1));
+                    t3i = a.uget((i, kc, 3)) + a.uget((i, k, 2));
+                    t4r = a.uget((i, k, 1)) - a.uget((i, kc, 0));
+                    t4i = a.uget((i, kc, 2)) + a.uget((i, k, 3));
+                    x1p = t3r + t4i;
+                    y1p = t3i - t4r;
+                    x2p = t1r - t2r;
+                    y2p = t1i - t2i;
+                    x3p = t3r - t4i;
+                    y3p = t3i + t4r;
+                    *b.uget_mut((i, 0, k)) = t1r + t2r;
+                    *b.uget_mut((i, 0, kc)) = t1i + t2i;
+                    *b.uget_mut((i, 1, k)) = c1k * x1p - s1k * y1p;
+                    *b.uget_mut((i, 1, kc)) = c1k * y1p + s1k * x1p;
+                    *b.uget_mut((i, 2, k)) = c2k * x2p - s2k * y2p;
+                    *b.uget_mut((i, 2, kc)) = c2k * y2p + s2k * x2p;
+                    *b.uget_mut((i, 3, k)) = c3k * x3p - s3k * y3p;
+                    *b.uget_mut((i, 3, kc)) = c3k * y3p + s3k * x3p;
+                }
             }
         }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[k, 0]];
-            s1k = sine[[k, 0]];
-            c2k = cosine[[k, 1]];
-            s2k = sine[[k, 1]];
-            c3k = cosine[[k, 2]];
-            s3k = sine[[k, 2]];
-            for i in 0..nv {
-                t1r = a[[i, k, 0]] + a[[i, kc, 1]];
-                t1i = a[[i, kc, 3]] - a[[i, k, 2]];
-                t2r = a[[i, k, 1]] + a[[i, kc, 0]];
-                t2i = a[[i, kc, 2]] - a[[i, k, 3]];
-                t3r = a[[i, k, 0]] - a[[i, kc, 1]];
-                t3i = a[[i, kc, 3]] + a[[i, k, 2]];
-                t4r = a[[i, k, 1]] - a[[i, kc, 0]];
-                t4i = a[[i, kc, 2]] + a[[i, k, 3]];
-                x1p = t3r + t4i;
-                y1p = t3i - t4r;
-                x2p = t1r - t2r;
-                y2p = t1i - t2i;
-                x3p = t3r - t4i;
-                y3p = t3i + t4r;
-                b[[i, 0, k]] = t1r + t2r;
-                b[[i, 0, kc]] = t1i + t2i;
-                b[[i, 1, k]] = c1k * x1p - s1k * y1p;
-                b[[i, 1, kc]] = c1k * y1p + s1k * x1p;
-                b[[i, 2, k]] = c2k * x2p - s2k * y2p;
-                b[[i, 2, kc]] = c2k * y2p + s2k * x2p;
-                b[[i, 3, k]] = c3k * x3p - s3k * y3p;
-                b[[i, 3, kc]] = c3k * y3p + s3k * x3p;
-            }
-        }
-    }
 
-    //Catch the case k=lv/2 when lv even:
-    if lv % 2 == 0 {
-        let lvd2 = lv / 2;
-        for i in 0..nv {
-            b[[i, 0, lvd2]] = a[[i, lvd2, 0]] + a[[i, lvd2, 1]];
-            b[[i, 2, lvd2]] = a[[i, lvd2, 3]] - a[[i, lvd2, 2]];
-            t3r = a[[i, lvd2, 0]] - a[[i, lvd2, 1]];
-            t4r = a[[i, lvd2, 3]] + a[[i, lvd2, 2]];
-            b[[i, 1, lvd2]] = FRAC_1_SQRT_2 * (t3r + t4r);
-            b[[i, 3, lvd2]] = FRAC_1_SQRT_2 * (t4r - t3r);
+        //Catch the case k=lv/2 when lv even:
+        if lv % 2 == 0 {
+            let lvd2 = lv / 2;
+            for i in 0..nv {
+                *b.uget_mut((i, 0, lvd2)) = a.uget((i, lvd2, 0)) + a.uget((i, lvd2, 1));
+                *b.uget_mut((i, 2, lvd2)) = a.uget((i, lvd2, 3)) - a.uget((i, lvd2, 2));
+                t3r = a.uget((i, lvd2, 0)) - a.uget((i, lvd2, 1));
+                t4r = a.uget((i, lvd2, 3)) + a.uget((i, lvd2, 2));
+                *b.uget_mut((i, 1, lvd2)) = FRAC_1_SQRT_2 * (t3r + t4r);
+                *b.uget_mut((i, 3, lvd2)) = FRAC_1_SQRT_2 * (t4r - t3r);
+            }
         }
     }
 }
@@ -594,61 +600,63 @@ pub fn revrdx3(
 
     let mut kc: usize;
 
-    for i in 0..nv {
-        t1r = a[[i, 0, 1]];
-        t2r = a[[i, 0, 0]] - 0.5 * t1r;
-        t3r = SINFPI3 * a[[i, 0, 2]];
-        b[[i, 0, 0]] = a[[i, 0, 0]] + t1r;
-        b[[i, 1, 0]] = t2r + t3r;
-        b[[i, 2, 0]] = t2r - t3r;
-    }
-
-    if nv <= (lv - 1) / 2 {
+    unsafe {
         for i in 0..nv {
+            t1r = *a.uget((i, 0, 1));
+            t2r = a.uget((i, 0, 0)) - 0.5 * t1r;
+            t3r = SINFPI3 * a.uget((i, 0, 2));
+            *b.uget_mut((i, 0, 0)) = a.uget((i, 0, 0)) + t1r;
+            *b.uget_mut((i, 1, 0)) = t2r + t3r;
+            *b.uget_mut((i, 2, 0)) = t2r - t3r;
+        }
+
+        if nv <= (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+                    t1r = a.uget((i, k, 1)) + a.uget((i, kc, 0));
+                    t1i = a.uget((i, kc, 1)) - a.uget((i, k, 2));
+                    t2r = a.uget((i, k, 0)) - 0.5 * t1r;
+                    t2i = a.uget((i, kc, 2)) - 0.5 * t1i;
+                    t3r = SINFPI3 * (a.uget((i, k, 1)) - a.uget((i, kc, 0)));
+                    t3i = SINFPI3 * (a.uget((i, kc, 1)) + a.uget((i, k, 2)));
+                    x1p = t2r + t3i;
+                    y1p = t2i - t3r;
+                    x2p = t2r - t3i;
+                    y2p = t2i + t3r;
+                    *b.uget_mut((i, 0, k)) = a.uget((i, k, 0)) + t1r;
+                    *b.uget_mut((i, 0, kc)) = a.uget((i, kc, 2)) + t1i;
+                    *b.uget_mut((i, 1, k)) = cosine.uget((k, 0)) * x1p - sine.uget((k, 0)) * y1p;
+                    *b.uget_mut((i, 1, kc)) = sine.uget((k, 0)) * x1p + cosine.uget((k, 0)) * y1p;
+                    *b.uget_mut((i, 2, k)) = cosine.uget((k, 1)) * x2p - sine.uget((k, 1)) * y2p;
+                    *b.uget_mut((i, 2, kc)) = sine.uget((k, 1)) * x2p + cosine.uget((k, 1)) * y2p;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
-                t1r = a[[i, k, 1]] + a[[i, kc, 0]];
-                t1i = a[[i, kc, 1]] - a[[i, k, 2]];
-                t2r = a[[i, k, 0]] - 0.5 * t1r;
-                t2i = a[[i, kc, 2]] - 0.5 * t1i;
-                t3r = SINFPI3 * (a[[i, k, 1]] - a[[i, kc, 0]]);
-                t3i = SINFPI3 * (a[[i, kc, 1]] + a[[i, k, 2]]);
-                x1p = t2r + t3i;
-                y1p = t2i - t3r;
-                x2p = t2r - t3i;
-                y2p = t2i + t3r;
-                b[[i, 0, k]] = a[[i, k, 0]] + t1r;
-                b[[i, 0, kc]] = a[[i, kc, 2]] + t1i;
-                b[[i, 1, k]] = cosine[[k, 0]] * x1p - sine[[k, 0]] * y1p;
-                b[[i, 1, kc]] = sine[[k, 0]] * x1p + cosine[[k, 0]] * y1p;
-                b[[i, 2, k]] = cosine[[k, 1]] * x2p - sine[[k, 1]] * y2p;
-                b[[i, 2, kc]] = sine[[k, 1]] * x2p + cosine[[k, 1]] * y2p;
-            }
-        }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[k, 0]];
-            s1k = sine[[k, 0]];
-            c2k = cosine[[k, 1]];
-            s2k = sine[[k, 1]];
-            for i in 0..nv {
-                t1r = a[[i, k, 1]] + a[[i, kc, 0]];
-                t1i = a[[i, kc, 1]] - a[[i, k, 2]];
-                t2r = a[[i, k, 0]] - 0.5 * t1r;
-                t2i = a[[i, kc, 2]] - 0.5 * t1i;
-                t3r = SINFPI3 * (a[[i, k, 1]] - a[[i, kc, 0]]);
-                t3i = SINFPI3 * (a[[i, kc, 1]] + a[[i, k, 2]]);
-                x1p = t2r + t3i;
-                y1p = t2i - t3r;
-                x2p = t2r - t3i;
-                y2p = t2i + t3r;
-                b[[i, 0, k]] = a[[i, k, 0]] + t1r;
-                b[[i, 0, kc]] = a[[i, kc, 2]] + t1i;
-                b[[i, 1, k]] = c1k * x1p - s1k * y1p;
-                b[[i, 1, kc]] = s1k * x1p + c1k * y1p;
-                b[[i, 2, k]] = c2k * x2p - s2k * y2p;
-                b[[i, 2, kc]] = s2k * x2p + c2k * y2p;
+                c1k = *cosine.uget((k, 0));
+                s1k = *sine.uget((k, 0));
+                c2k = *cosine.uget((k, 1));
+                s2k = *sine.uget((k, 1));
+                for i in 0..nv {
+                    t1r = a.uget((i, k, 1)) + a.uget((i, kc, 0));
+                    t1i = a.uget((i, kc, 1)) - a.uget((i, k, 2));
+                    t2r = a.uget((i, k, 0)) - 0.5 * t1r;
+                    t2i = a.uget((i, kc, 2)) - 0.5 * t1i;
+                    t3r = SINFPI3 * (a.uget((i, k, 1)) - a.uget((i, kc, 0)));
+                    t3i = SINFPI3 * (a.uget((i, kc, 1)) + a.uget((i, k, 2)));
+                    x1p = t2r + t3i;
+                    y1p = t2i - t3r;
+                    x2p = t2r - t3i;
+                    y2p = t2i + t3r;
+                    *b.uget_mut((i, 0, k)) = a.uget((i, k, 0)) + t1r;
+                    *b.uget_mut((i, 0, kc)) = a.uget((i, kc, 2)) + t1i;
+                    *b.uget_mut((i, 1, k)) = c1k * x1p - s1k * y1p;
+                    *b.uget_mut((i, 1, kc)) = s1k * x1p + c1k * y1p;
+                    *b.uget_mut((i, 2, k)) = c2k * x2p - s2k * y2p;
+                    *b.uget_mut((i, 2, kc)) = s2k * x2p + c2k * y2p;
+                }
             }
         }
     }
@@ -684,40 +692,42 @@ pub fn revrdx2(
 
     let mut kc: usize;
 
-    // Do k=0 first:
-    for i in 0..nv {
-        b[[i, 0, 0]] = a[[i, 0, 0]] + a[[i, 0, 1]];
-        b[[i, 1, 0]] = a[[i, 0, 0]] - a[[i, 0, 1]];
-    }
-
-    // !Next do remaining k:
-    if nv < (lv - 1) / 2 {
+    unsafe {
+        // Do k=0 first:
         for i in 0..nv {
+            *b.uget_mut((i, 0, 0)) = a.uget((i, 0, 0)) + a.uget((i, 0, 1));
+            *b.uget_mut((i, 1, 0)) = a.uget((i, 0, 0)) - a.uget((i, 0, 1));
+        }
+
+        // !Next do remaining k:
+        if nv < (lv - 1) / 2 {
+            for i in 0..nv {
+                for k in 1..=(lv - 1) / 2 {
+                    kc = lv - k;
+
+                    x1p = a.uget((i, k, 0)) - a.uget((i, kc, 0));
+                    y1p = a.uget((i, kc, 1)) + a.uget((i, k, 1));
+
+                    *b.uget_mut((i, 0, k)) = a.uget((i, k, 0)) + a.uget((i, kc, 0));
+                    *b.uget_mut((i, 0, kc)) = a.uget((i, kc, 1)) - a.uget((i, k, 1));
+                    *b.uget_mut((i, 1, k)) = cosine.uget((k, 0)) * x1p - sine.uget((k, 0)) * y1p;
+                    *b.uget_mut((i, 1, kc)) = cosine.uget((k, 0)) * y1p + sine.uget((k, 0)) * x1p;
+                }
+            }
+        } else {
             for k in 1..=(lv - 1) / 2 {
                 kc = lv - k;
+                c1k = *cosine.uget((k, 0));
+                s1k = *sine.uget((k, 0));
 
-                x1p = a[[i, k, 0]] - a[[i, kc, 0]];
-                y1p = a[[i, kc, 1]] + a[[i, k, 1]];
-
-                b[[i, 0, k]] = a[[i, k, 0]] + a[[i, kc, 0]];
-                b[[i, 0, kc]] = a[[i, kc, 1]] - a[[i, k, 1]];
-                b[[i, 1, k]] = cosine[[k, 0]] * x1p - sine[[k, 0]] * y1p;
-                b[[i, 1, kc]] = cosine[[k, 0]] * y1p + sine[[k, 0]] * x1p;
-            }
-        }
-    } else {
-        for k in 1..=(lv - 1) / 2 {
-            kc = lv - k;
-            c1k = cosine[[k, 0]];
-            s1k = sine[[k, 0]];
-
-            for i in 0..nv {
-                x1p = a[[i, k, 0]] - a[[i, kc, 0]];
-                y1p = a[[i, kc, 1]] + a[[i, k, 1]];
-                b[[i, 0, k]] = a[[i, k, 0]] + a[[i, kc, 0]];
-                b[[i, 0, kc]] = a[[i, kc, 1]] - a[[i, k, 1]];
-                b[[i, 1, k]] = c1k * x1p - s1k * y1p;
-                b[[i, 1, kc]] = c1k * y1p + s1k * x1p;
+                for i in 0..nv {
+                    x1p = a.uget((i, k, 0)) - a.uget((i, kc, 0));
+                    y1p = a.uget((i, kc, 1)) + a.uget((i, k, 1));
+                    *b.uget_mut((i, 0, k)) = a.uget((i, k, 0)) + a.uget((i, kc, 0));
+                    *b.uget_mut((i, 0, kc)) = a.uget((i, kc, 1)) - a.uget((i, k, 1));
+                    *b.uget_mut((i, 1, k)) = c1k * x1p - s1k * y1p;
+                    *b.uget_mut((i, 1, kc)) = c1k * y1p + s1k * x1p;
+                }
             }
         }
     }


### PR DESCRIPTION
In the lowest level routines, unchecked indexing of the matrices can be used as the bounds are checked manually with assertions at the start of each function.

This PR resulted in significant performance improvement:
<img width="587" alt="Screenshot 2020-01-16 at 12 35 36" src="https://user-images.githubusercontent.com/8290136/72525733-bd29c780-385c-11ea-95e1-2e2fe869dd64.png">
