### PR TITLE
Add `quit::main` macro

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use {
     },
 };
 
+#[quit::main]
 fn main() {
     TermLogger::init(LevelFilter::Info, LogConfig::default(), TerminalMode::Mixed)
         .expect("No interactive terminal");


### PR DESCRIPTION
Hi. I was searching to see how my crates are being used and noticed that the `quit::main` macro is missing here, which Quit uses to set the exit code. Without it, the exit code will end up being 101, but relying on this is not ideal. This PR fixes that.